### PR TITLE
Use new slack incoming-webhook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ prefix: `consul-alerts/config/notifiers/slack/`
 |--------------|-----------------------------------------------------|
 | enabled      | Enable the Slack notifier. [Default: false]         |
 | cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
-| team         | The slack team name (mandatory)                     |
-| token        | The token for the webhook api (mandatory)           |
+| url          | The incoming-webhook url (mandatory)                |
 | channel      | The channel to post the notification (mandatory)    |
 | username     | The username to appear on the post                  |
 | icon-url     | URL of a custom image for the notification          |

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -187,8 +187,7 @@ func builtinNotifiers() []notifier.Notifier {
 	if slackConfig.Enabled {
 		slackNotifier := &notifier.SlackNotifier{
 			ClusterName: slackConfig.ClusterName,
-			Team:        slackConfig.Team,
-			Token:       slackConfig.Token,
+			Url:         slackConfig.Url,
 			Channel:     slackConfig.Channel,
 			Username:    slackConfig.Username,
 			IconUrl:     slackConfig.IconUrl,

--- a/consul/client.go
+++ b/consul/client.go
@@ -124,10 +124,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.Slack.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/slack/cluster-name":
 				valErr = loadCustomValue(&config.Notifiers.Slack.ClusterName, val, ConfigTypeString)
-			case "consul-alerts/config/notifiers/slack/team":
-				valErr = loadCustomValue(&config.Notifiers.Slack.Team, val, ConfigTypeString)
-			case "consul-alerts/config/notifiers/slack/token":
-				valErr = loadCustomValue(&config.Notifiers.Slack.Token, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/slack/url":
+				valErr = loadCustomValue(&config.Notifiers.Slack.Url, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/slack/channel":
 				valErr = loadCustomValue(&config.Notifiers.Slack.Channel, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/slack/username":

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -79,8 +79,7 @@ type InfluxdbNotifierConfig struct {
 type SlackNotifierConfig struct {
 	Enabled     bool
 	ClusterName string
-	Team        string
-	Token       string
+	Url         string
 	Channel     string
 	Username    string
 	IconUrl     string

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
-const SlackUrl = "https://%s.slack.com/services/hooks/incoming-webhook?token=%s"
 const header = `%s is %s.
 
 Fail: %d, Warn: %d, Pass: %d
@@ -20,8 +19,7 @@ Fail: %d, Warn: %d, Pass: %d
 
 type SlackNotifier struct {
 	ClusterName string `json:"-"`
-	Team        string `json:"-"`
-	Token       string `json:"-"`
+	Url         string `json:"-"`
 	Channel     string `json:"channel"`
 	Username    string `json:"username"`
 	IconUrl     string `json:"icon_url"`
@@ -39,7 +37,6 @@ func (slack *SlackNotifier) Notify(messages Messages) bool {
 		text += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
 	}
 
-	url := fmt.Sprintf(SlackUrl, slack.Team, slack.Token)
 	slack.Text = text
 
 	data, err := json.Marshal(slack)
@@ -49,7 +46,7 @@ func (slack *SlackNotifier) Notify(messages Messages) bool {
 	}
 
 	b := bytes.NewBuffer(data)
-	if res, err := http.Post(url, "application/json", b); err != nil {
+	if res, err := http.Post(slack.Url, "application/json", b); err != nil {
 		log.Println("Unable to send data to slack:", err)
 		return false
 	} else {


### PR DESCRIPTION
Slack doesn't appear to give out tokens anymore for webhooks, but instead generates a url to use. 

![slack-hooks](https://cloud.githubusercontent.com/assets/67717/5507485/7f0550b0-8771-11e4-83e1-69a7ba164928.jpg)
