### PR TITLE
More visible output in consul slack alerts

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -192,6 +192,7 @@ func builtinNotifiers() []notifier.Notifier {
 			Username:    slackConfig.Username,
 			IconUrl:     slackConfig.IconUrl,
 			IconEmoji:   slackConfig.IconEmoji,
+			Detailed:    slackConfig.Detailed,
 		}
 		notifiers = append(notifiers, slackNotifier)
 	}

--- a/consul/client.go
+++ b/consul/client.go
@@ -134,6 +134,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.Slack.IconUrl, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/slack/icon-emoji":
 				valErr = loadCustomValue(&config.Notifiers.Slack.IconEmoji, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/slack/detailed":
+				valErr = loadCustomValue(&config.Notifiers.Slack.Detailed, val, ConfigTypeBool)
 
 			case "consul-alerts/config/notifiers/pagerduty/enabled":
 				valErr = loadCustomValue(&config.Notifiers.PagerDuty.Enabled, val, ConfigTypeBool)

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -84,6 +84,7 @@ type SlackNotifierConfig struct {
 	Username    string
 	IconUrl     string
 	IconEmoji   string
+	Detailed    bool
 }
 
 type PagerDutyNotifierConfig struct {

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -115,6 +115,7 @@ func (slack *SlackNotifier) postToSlack() bool {
 		log.Println("Unable to marshal slack payload:", err)
 		return false
 	}
+	log.Debugf("struct = %+v, json = %s", slack, string(data))
 
 	b := bytes.NewBuffer(data)
 	if res, err := http.Post(slack.Url, "application/json", b); err != nil {

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -25,9 +25,18 @@ type SlackNotifier struct {
 	IconUrl     string `json:"icon_url"`
 	IconEmoji   string `json:"icon_emoji"`
 	Text        string `json:"text"`
+	Detailed    bool   `json:"-"`
 }
 
 func (slack *SlackNotifier) Notify(messages Messages) bool {
+	if slack.Detailed {
+		return slack.notifyDetailed(messages)
+	} else {
+		return slack.notifySimple(messages)
+	}
+}
+
+func (slack *SlackNotifier) notifySimple(messages Messages) bool {
 
 	overallStatus, pass, warn, fail := messages.Summary()
 
@@ -63,4 +72,8 @@ func (slack *SlackNotifier) Notify(messages Messages) bool {
 		}
 	}
 
+}
+
+func (slack *SlackNotifier) notifyDetailed(messages Messages) bool {
+	// TBD
 }

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -18,22 +18,32 @@ Fail: %d, Warn: %d, Pass: %d
 `
 
 type SlackNotifier struct {
-	ClusterName string `json:"-"`
-	Url         string `json:"-"`
-	Channel     string `json:"channel"`
-	Username    string `json:"username"`
-	IconUrl     string `json:"icon_url"`
-	IconEmoji   string `json:"icon_emoji"`
-	Text        string `json:"text"`
-	Detailed    bool   `json:"-"`
+	ClusterName string       `json:"-"`
+	Url         string       `json:"-"`
+	Channel     string       `json:"channel"`
+	Username    string       `json:"username"`
+	IconUrl     string       `json:"icon_url"`
+	IconEmoji   string       `json:"icon_emoji"`
+	Text        string       `json:"text"`
+	Attachments []attachment `json:"attachments"`
+	Detailed    bool         `json:"-"`
+}
+
+type attachment struct {
+	title     string
+	pretext   string
+	text      string
+	mrkdwn_in []string
 }
 
 func (slack *SlackNotifier) Notify(messages Messages) bool {
+
 	if slack.Detailed {
 		return slack.notifyDetailed(messages)
 	} else {
 		return slack.notifySimple(messages)
 	}
+
 }
 
 func (slack *SlackNotifier) notifySimple(messages Messages) bool {
@@ -48,6 +58,18 @@ func (slack *SlackNotifier) notifySimple(messages Messages) bool {
 	}
 
 	slack.Text = text
+
+	return slack.postToSlack()
+
+}
+
+func (slack *SlackNotifier) notifyDetailed(messages Messages) bool {
+	// TBD
+	return slack.postToSlack()
+
+}
+
+func (slack *SlackNotifier) postToSlack() bool {
 
 	data, err := json.Marshal(slack)
 	if err != nil {
@@ -72,8 +94,4 @@ func (slack *SlackNotifier) notifySimple(messages Messages) bool {
 		}
 	}
 
-}
-
-func (slack *SlackNotifier) notifyDetailed(messages Messages) bool {
-	// TBD
 }

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -82,11 +82,11 @@ func (slack *SlackNotifier) notifyDetailed(messages Messages) bool {
 	pretext := fmt.Sprintf("%s %s is *%s*", emoji, slack.ClusterName, overallStatus)
 
 	detailedBody := ""
-	detailedBody += fmt.Sprintf("Fail: %d, Warn: %d, Pass: %d\n", fail, warn, pass)
+	detailedBody += fmt.Sprintf("*Changes:* Fail = %d, Warn = %d, Pass = %d\n", fail, warn, pass)
 	detailedBody += fmt.Sprintf("\n")
 
 	for _, message := range messages {
-		detailedBody += fmt.Sprintf("\n*%s:%s:%s is %s.*", message.Node, message.Service, message.Check, message.Status)
+		detailedBody += fmt.Sprintf("\n%s:%s:%s is *%s.*", message.Node, message.Service, message.Check, message.Status)
 		detailedBody += fmt.Sprintf("\n`%s`", message.Output)
 	}
 


### PR DESCRIPTION
Hi, I have made a more stylish slack alert format.

Set `consul-alerts/config/notifiers/slack/detailed` to `true` to enable this.

![2015-04-06 17 56 40](https://cloud.githubusercontent.com/assets/91011/7002504/e392488e-dc86-11e4-8b89-7d95acae1810.png)
