### PR TITLE
Fix non-standard imports

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -8,8 +8,8 @@ import (
 
 	"encoding/json"
 
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
-	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/armon/consul-api"
+	log "github.com/Sirupsen/logrus"
+	"github.com/armon/consul-api"
 )
 
 const (

--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -7,7 +7,7 @@ import (
 	"html/template"
 	"net/smtp"
 
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type EmailNotifier struct {

--- a/notifier/hipchat-notifier.go
+++ b/notifier/hipchat-notifier.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/tbruyelle/hipchat-go/hipchat"
 
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type HipChatNotifier struct {

--- a/notifier/influxdb-notifier.go
+++ b/notifier/influxdb-notifier.go
@@ -1,8 +1,8 @@
 package notifier
 
 import (
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
-	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/influxdb/influxdb/client"
+	log "github.com/Sirupsen/logrus"
+	"github.com/influxdb/influxdb/client"
 )
 
 type InfluxdbNotifier struct {

--- a/notifier/log-notifier.go
+++ b/notifier/log-notifier.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 type LogNotifier struct {

--- a/notifier/pagerduty-notifier.go
+++ b/notifier/pagerduty-notifier.go
@@ -1,9 +1,9 @@
 package notifier
 
 import (
-	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/darkcrux/gopherduty"
+	"github.com/darkcrux/gopherduty"
 
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type PagerDutyNotifier struct {

--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type SlackNotifier struct {


### PR DESCRIPTION
While packaging consul-alerts for Debian, I noticed a couple of bogus import paths. 

This is my first time packaging golang application. So, please review accordingly.