### PR TITLE
Add the `version` header before flushing response

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -139,8 +139,8 @@ func watchMode(arguments map[string]interface{}) {
 }
 
 func infoHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(201)
 	w.Header().Add("version", version)
+	w.WriteHeader(201)
 }
 
 func cleanup() {


### PR DESCRIPTION
Before:
```
$ curl 0:9000/v1/info -qvs 2>&1 | grep '<'
< HTTP/1.1 201 Created
< Date: Mon, 29 Jun 2015 16:36:03 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
<
```

After:
```
$ curl 0:9000/v1/info -qvs 2>&1 | grep '<'
< HTTP/1.1 201 Created
< Version: Consul Alerts 0.3.0
< Date: Mon, 29 Jun 2015 17:30:32 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
<
```