### PR TITLE
Fix health checks not being processed if any blacklisted

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -236,7 +236,7 @@ func (c *ConsulAlertClient) UpdateCheckData() {
 
 		if c.IsBlacklisted(&localHealth) {
 			log.Printf("%s:%s:%s is blacklisted.", node, service, check)
-			return
+			continue
 		}
 
 		if !existing {


### PR DESCRIPTION
If I blacklist other nodes, I no longer receive notifications for the health checks I do care about.