### PR TITLE
opsgenie client renamed SetApiKey to SetAPIKey

### DIFF
--- a/consul/interface.go
+++ b/consul/interface.go
@@ -107,7 +107,7 @@ type HipChatNotifierConfig struct {
 type OpsGenieNotifierConfig struct {
 	Enabled     bool
 	ClusterName string
-	ApiKey   string
+	ApiKey      string
 }
 
 type Status struct {

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -11,7 +11,7 @@ import (
 
 type OpsGenieNotifier struct {
 	ClusterName string
-	ApiKey   string
+	ApiKey      string
 }
 
 func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
@@ -50,10 +50,10 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 
 func (opsgenie *OpsGenieNotifier) Send(alertCli *ogcli.OpsGenieAlertClient, message string, content string) (*alerts.CreateAlertResponse, error) {
 	req := alerts.CreateAlertRequest{
-		Message:         message,
-		Description:     content,
-		Source:          "consul",
-		Entity:          opsgenie.ClusterName,
+		Message:     message,
+		Description: content,
+		Source:      "consul",
+		Entity:      opsgenie.ClusterName,
 	}
 	return alertCli.Create(req)
 }

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -19,7 +19,7 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 	overallStatus, pass, warn, fail := messages.Summary()
 
 	client := new(ogcli.OpsGenieClient)
-	client.SetApiKey(opsgenie.ApiKey)
+	client.SetAPIKey(opsgenie.ApiKey)
 
 	alertCli, cliErr := client.Alert()
 


### PR DESCRIPTION
see https://github.com/opsgenie/opsgenie-go-sdk/commit/d2a50423187d552340874644ed9ff3b43252a871#diff-1cd41a2611da49ce63630d5a51bd82c5R100 in the opsgenie/opsgenie-go-sdk repo

It is currently not possible to get the dependencies and build the project without this change:

```
$ go get
# github.com/AcalephStorage/consul-alerts/notifier
notifier/opsgenie-notifier.go:22: client.SetApiKey undefined (type *"github.com/opsgenie/opsgenie-go-sdk/client".OpsGenieClient has no field or method SetApiKey)
```