### PR TITLE
Fix OpsGenie client.SetAPIKey()

### DIFF
--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -19,7 +19,7 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 	overallStatus, pass, warn, fail := messages.Summary()
 
 	client := new(ogcli.OpsGenieClient)
-	client.SetApiKey(opsgenie.ApiKey)
+	client.SetAPIKey(opsgenie.ApiKey)
 
 	alertCli, cliErr := client.Alert()
 


### PR DESCRIPTION
The OpsGenie go sdk changed its interface w/ this change:
https://github.com/opsgenie/opsgenie-go-sdk/commit/d2a50423187d552340874644ed9ff3b43252a871