### PR TITLE
Add logging and sleeps for leader election

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -22,7 +22,7 @@ const usage = `Consul Alerts.
 
 Usage:
   consul-alerts start [--alert-addr=<addr>] [--consul-addr=<consuladdr>] [--consul-dc=<dc>] [--consul-acl-token=<token>] [--watch-checks] [--watch-events] [--log-level=<level>]
-  consul-alerts watch (checks|event) [--alert-addr=<addr>]
+  consul-alerts watch (checks|event) [--alert-addr=<addr>] [--log-level=<level>]
   consul-alerts --help
   consul-alerts --version
 
@@ -33,8 +33,7 @@ Options:
   --consul-dc=<dc>             The consul datacenter [default: dc1].
   --watch-checks               Run check watcher.
   --watch-events               Run event watcher.
-	--log-level=<level>          Set the logging level - valid values are "debug",
-												         "info", "warn" (default), and "err".
+	--log-level=<level>          Set the logging level - valid values are "debug", "info", "warn" (default), and "err".
   --help                       Show this screen.
   --version                    Show version.
 
@@ -50,7 +49,16 @@ func main() {
 	log.SetLevel(log.InfoLevel)
 	args, _ := docopt.Parse(usage, nil, true, version, false)
 
-	loglevelString := args["--log-level"].(string)
+	switch {
+	case args["start"].(bool):
+		daemonMode(args)
+	case args["watch"].(bool):
+		watchMode(args)
+	}
+}
+
+func daemonMode(arguments map[string]interface{}) {
+	loglevelString, _ := args["--log-level"].(string)
 
 	if loglevelString != "" {
 		loglevel, err := log.ParseLevel(loglevelString)
@@ -61,15 +69,6 @@ func main() {
 		}
 	}
 
-	switch {
-	case args["start"].(bool):
-		daemonMode(args)
-	case args["watch"].(bool):
-		watchMode(args)
-	}
-}
-
-func daemonMode(arguments map[string]interface{}) {
 	addr := arguments["--alert-addr"].(string)
 
 	url := fmt.Sprintf("http://%s/v1/info", addr)
@@ -127,6 +126,17 @@ func daemonMode(arguments map[string]interface{}) {
 }
 
 func watchMode(arguments map[string]interface{}) {
+	loglevelString, _ := args["--log-level"].(string)
+
+	if loglevelString != "" {
+		loglevel, err := log.ParseLevel(loglevelString)
+		if err == nil {
+			log.SetLevel(loglevel)
+		} else {
+			log.Println("Log level not set:", err)
+		}
+	}
+
 	checkMode := arguments["checks"].(bool)
 	eventMode := arguments["event"].(bool)
 	addr := arguments["--alert-addr"].(string)

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -58,7 +58,7 @@ func main() {
 }
 
 func daemonMode(arguments map[string]interface{}) {
-	loglevelString, _ := args["--log-level"].(string)
+	loglevelString, _ := arguments["--log-level"].(string)
 
 	if loglevelString != "" {
 		loglevel, err := log.ParseLevel(loglevelString)
@@ -126,7 +126,7 @@ func daemonMode(arguments map[string]interface{}) {
 }
 
 func watchMode(arguments map[string]interface{}) {
-	loglevelString, _ := args["--log-level"].(string)
+	loglevelString, _ := arguments["--log-level"].(string)
 
 	if loglevelString != "" {
 		loglevel, err := log.ParseLevel(loglevelString)

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -21,7 +21,7 @@ const version = "Consul Alerts 0.3.2"
 const usage = `Consul Alerts.
 
 Usage:
-  consul-alerts start [--alert-addr=<addr>] [--consul-addr=<consuladdr>] [--consul-dc=<dc>] [--consul-acl-token=<token>] [--watch-checks] [--watch-events]
+  consul-alerts start [--alert-addr=<addr>] [--consul-addr=<consuladdr>] [--consul-dc=<dc>] [--consul-acl-token=<token>] [--watch-checks] [--watch-events] [--log-level=<level>]
   consul-alerts watch (checks|event) [--alert-addr=<addr>]
   consul-alerts --help
   consul-alerts --version
@@ -33,6 +33,8 @@ Options:
   --consul-dc=<dc>             The consul datacenter [default: dc1].
   --watch-checks               Run check watcher.
   --watch-events               Run event watcher.
+	--log-level=<level>          Set the logging level - valid values are "debug",
+												         "info", "warn" (default), and "err".
   --help                       Show this screen.
   --version                    Show version.
 
@@ -47,6 +49,18 @@ var consulClient consul.Consul
 func main() {
 	log.SetLevel(log.InfoLevel)
 	args, _ := docopt.Parse(usage, nil, true, version, false)
+
+	loglevelString := args["--log-level"].(string)
+
+	if loglevelString != "" {
+		loglevel, err := log.ParseLevel(loglevelString)
+		if err == nil {
+			log.SetLevel(loglevel)
+		} else {
+			log.Println("Log level not set:", err)
+		}
+	}
+
 	switch {
 	case args["start"].(bool):
 		daemonMode(args)

--- a/consul/client.go
+++ b/consul/client.go
@@ -39,9 +39,20 @@ func NewClient(address, dc, aclToken string) (*ConsulAlertClient, error) {
 		config: alertConfig,
 	}
 
-	log.Println("Checking consul agent connection...")
-	if _, err := client.api.Status().Leader(); err != nil {
-		return nil, err
+	try := 1
+	for {
+		try += try
+		log.Println("Checking consul agent connection...")
+		_, err := client.api.Status().Leader()
+		if err != nil {
+			log.Println("Waiting for consul:", err)
+			if try > 10 {
+				return nil, err
+			}
+			time.Sleep(10000 * time.Millisecond)
+		} else {
+			break
+		}
 	}
 
 	client.LoadConfig()

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -107,7 +107,7 @@ type HipChatNotifierConfig struct {
 type OpsGenieNotifierConfig struct {
 	Enabled     bool
 	ClusterName string
-	ApiKey   string
+	ApiKey      string
 }
 
 type Status struct {

--- a/leader-election.go
+++ b/leader-election.go
@@ -3,6 +3,7 @@ package main
 import (
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	consulapi "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+	"time"
 )
 
 const LockKey = "consul-alerts/leader"
@@ -31,6 +32,8 @@ func (l *LeaderElection) start() {
 				log.Infoln("Lost leadership.")
 				l.lock.Unlock()
 				l.lock.Destroy()
+			} else {
+				time.Sleep(10000 * time.Millisecond)
 			}
 		}
 	}

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -11,7 +11,7 @@ import (
 
 type OpsGenieNotifier struct {
 	ClusterName string
-	ApiKey   string
+	ApiKey      string
 }
 
 func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
@@ -50,10 +50,10 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 
 func (opsgenie *OpsGenieNotifier) Send(alertCli *ogcli.OpsGenieAlertClient, message string, content string) (*alerts.CreateAlertResponse, error) {
 	req := alerts.CreateAlertRequest{
-		Message:         message,
-		Description:     content,
-		Source:          "consul",
-		Entity:          opsgenie.ClusterName,
+		Message:     message,
+		Description: content,
+		Source:      "consul",
+		Entity:      opsgenie.ClusterName,
 	}
 	return alertCli.Create(req)
 }


### PR DESCRIPTION
Hi, we have had some issues of consul-alerts request swamping consul when consul-alerts and consul come up simultaneously on a new cluster.  In our system the daemonized consul-alerts will immediately try again and again if consul is still electing leader and end up interfering.  So I added 10 second sleeps to both consul and consul-alert leader elections.  For the consul, it also tries ten times before giving up.
I believe these should improve leader election.

In addition, I added log level support.  Right now it appears everything goes to INFO and it is quite chatty about mundane things like not being the leader.  In general logs need assigned better classification and multiples should be suppressed.  Anyway, this allows a temporary fix of setting the log level higher.