### PR TITLE
Add support for 'from' for hipchat notifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ prefix: `consul-alerts/config/notifiers/hipchat/`
 | key          | description                                         |
 |--------------|-----------------------------------------------------|
 | enabled      | Enable the Hipchat notifier. [Default: false]       |
+| from         | The name to send notifications as                   |
 | cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
 | base-url     | HipChat base url                                    |
 | room-id      | The room to post to                  (mandatory)    |

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -248,6 +248,7 @@ func builtinNotifiers() []notifier.Notifier {
 			RoomId:      hipchatConfig.RoomId,
 			AuthToken:   hipchatConfig.AuthToken,
 			BaseURL:     hipchatConfig.BaseURL,
+			From:        hipchatConfig.From,
 		}
 		notifiers = append(notifiers, hipchatNotifier)
 	}

--- a/consul/client.go
+++ b/consul/client.go
@@ -169,6 +169,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.HipChat.AuthToken, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/hipchat/base-url":
 				valErr = loadCustomValue(&config.Notifiers.HipChat.BaseURL, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/hipchat/from":
+				valErr = loadCustomValue(&config.Notifiers.HipChat.From, val, ConfigTypeString)
 
 			// OpsGenie notifier config
 			case "consul-alerts/config/notifiers/opsgenie/enabled":

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -102,6 +102,7 @@ type HipChatNotifierConfig struct {
 	RoomId      string
 	AuthToken   string
 	BaseURL     string
+	From        string
 }
 
 type OpsGenieNotifierConfig struct {

--- a/notifier/hipchat-notifier.go
+++ b/notifier/hipchat-notifier.go
@@ -14,6 +14,7 @@ type HipChatNotifier struct {
 	RoomId      string
 	AuthToken   string
 	BaseURL     string
+	From        string
 }
 
 func (notifier *HipChatNotifier) Notify(messages Messages) bool {
@@ -43,7 +44,13 @@ func (notifier *HipChatNotifier) Notify(messages Messages) bool {
 		client.BaseURL = url
 	}
 
+	from := ""
+	if notifier.From != "" {
+		from := notifier.From
+	}
+
 	notifRq := &hipchat.NotificationRequest{
+		From:    from,
 		Message: text,
 		Color:   level,
 		Notify:  true,


### PR DESCRIPTION
This is an attempt at making it so we can pass the ["from" option](https://github.com/tbruyelle/hipchat-go/blob/9415f35af77982a56e08b861cfdb4f0263017d9b/hipchat/room.go#L78) supported by hipchat-go.  Right now, if I create an auth token in hipchat, then all the messages from consul-alerts show up as being from "Jason Walton", because this is the name associated with my account.  By providing the from option, we should be able to get these to show up as, for example, "Consul Alerts".

Before you read this, though: this is my first ever attempt at writing a line of go, so be forewarned.  :P  I also couldn't figure out how to build this, so it might not even compile.  I tired `make`, which gave me quite a few errors along the lines of:

```
check-handler.go:11:2: cannot find package "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus" in any of:
	/usr/local/Cellar/go/1.5.2/libexec/src/github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus (from $GOROOT)
	/Users/jwalton/go/src/github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus (from $GOPATH)
```

then I found the Godeps folder, so I tried `go get github.com/tools/godep`, and then `godep restore` (all the tutorials for godep tell you how to save your dependencies, but none of them mention the restore command), and this copied all these dependencies into /Users/jwalton/Development/consul-alerts/Godeps/_workspace, but this isn't in my go path.  I'm quite sure I'm doing something fundamentally wrong here.  :P