### PR TITLE
Add wildcard query API

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -109,6 +109,7 @@ func daemonMode(arguments map[string]interface{}) {
 	http.HandleFunc("/v1/info", infoHandler)
 	http.HandleFunc("/v1/process/events", ep.eventHandler)
 	http.HandleFunc("/v1/process/checks", cp.checkHandler)
+	http.HandleFunc("/v1/health/wildcard", healthWildcardHandler)
 	http.HandleFunc("/v1/health", healthHandler)
 	go startAPI(addr)
 

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -137,6 +137,7 @@ type Consul interface {
 	CheckChangeThreshold() int
 	UpdateCheckData()
 	NewAlerts() []Check
+	NewAlertsWithFilter(node string, service string, checkId string, statuses []string, ignoreBlacklist bool) []Check
 
 	IsBlacklisted(check *Check) bool
 

--- a/health-wildcard-handler.go
+++ b/health-wildcard-handler.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+func healthWildcardHandler(w http.ResponseWriter, r *http.Request) {
+
+	node := r.URL.Query().Get("node")
+	service := r.URL.Query().Get("service")
+	check := r.URL.Query().Get("check")
+	status := r.URL.Query().Get("status")
+	alwaysOk := r.URL.Query().Get("alwaysOk") != "" // Always return 200 code, even if failures in data
+	ignoreBlacklist := r.URL.Query().Get("ignoreBlacklist") != ""
+
+    var statuses []string
+    if status != "" {
+	    statuses = strings.Split(status, ",")
+    }
+	log.Printf("Query: node: %v, service: %v, check: %v, status: %v, alwaysOk: %v, ignoreBlacklist: %v", node, service, check, status, alwaysOk, ignoreBlacklist)
+
+	alerts := consulClient.NewAlertsWithFilter(node, service, check, statuses, ignoreBlacklist)
+
+	code := 200
+
+	if !alwaysOk {
+		var newCode int
+		for _, alert := range alerts {
+			switch alert.Status {
+			case "passing":
+				newCode = 200
+			case "warning", "critical":
+				newCode = 503
+			default:
+				status = "unknown"
+				newCode = 404
+			}
+			if newCode > code {
+				code = newCode
+			}
+		}
+	}
+
+	body, _ := json.Marshal(alerts)
+	w.WriteHeader(code)
+	w.Write([]byte(body))
+}


### PR DESCRIPTION
Extend `consul-alerts` API with `v1/health/wildcard`, which are similiar to `v1/health` but return all matched checks (omitted service/node/check params assumed as `any`) . Values returned in JSON form,  status code 503 if one of services in critical state.

Additional params to `ignoreBlacklist`, and `alwaysOk` (last one force status code to 200 disregarding checks status)