### PR TITLE
Avoid nil exception when the response from opsgenie is empty

### DIFF
--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -38,10 +38,13 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 		response, alertErr := opsgenie.Send(alertCli, title, content)
 
 		if alertErr != nil {
-			log.Println("Opsgenie notification trouble.", response.Status)
-			return false
-		}
-
+                        if response == nil {
+                                log.Println("Opsgenie notification trouble", alertErr)
+                        } else {
+                                log.Println("Opsgenie notification trouble.", response.Status)
+                        }
+                        return false
+                }
 	}
 
 	log.Println("Opsgenie notification send.")


### PR DESCRIPTION
When an alert is filtered by opsgenie, it didnt send an response. Because of that consult alert crash.