### PR TITLE
Improves reminders to prevent extra alerts after outage

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -23,7 +23,7 @@ type Message struct {
 	Output    string
 	Notes     string
 	Interval  int
-	IntCount  int
+	RmdCheck  time.Time
 	NotifList map[string]bool
 	Timestamp time.Time
 }


### PR DESCRIPTION
With the previous method after time offline the service would send at every reminder interval for a time until the interval count caught up.