### PR TITLE
Feature/autoclose opsgenie notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.5
 MAINTAINER Acaleph <admin@acale.ph>
 RUN apt-get update && apt-get install -y unzip --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN (curl -OL https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip &&\
-unzip 0.5.2_linux_amd64.zip &&\
+RUN (curl -OL https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip &&\
+unzip consul_0.5.2_linux_amd64.zip &&\
 chmod +x consul &&\
 mv consul /bin/ &&\
-rm 0.5.2_linux_amd64.zip)
+rm consul_0.5.2_linux_amd64.zip)
 
 ADD . /go/src/github.com/AcalephStorage/consul-alerts
 RUN go get github.com/AcalephStorage/consul-alerts

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -38,7 +38,7 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 	ok := true
 	for _, message := range messages {
 		title := fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
-		alias := opsgenie.CreateAlias(message)
+		alias := opsgenie.createAlias(message)
 		content := fmt.Sprintf(header, opsgenie.ClusterName, overallStatus, fail, warn, pass)
 		content += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
 		content += fmt.Sprintf("\n%s", message.Output)
@@ -46,11 +46,11 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 		// create the alert
 		switch {
 		case message.IsCritical():
-			ok = opsgenie.CreateAlert(alertCli, title, content, alias) && ok
+			ok = opsgenie.createAlert(alertCli, title, content, alias) && ok
 		case message.IsWarning():
-			ok = opsgenie.CreateAlert(alertCli, title, content, alias) && ok
+			ok = opsgenie.createAlert(alertCli, title, content, alias) && ok
 		case message.IsPassing():
-			ok = opsgenie.CloseAlert(alertCli, alias) && ok
+			ok = opsgenie.closeAlert(alertCli, alias) && ok
 		default:
 			ok = false
 			log.Warn("Message was not either IsCritical, IsWarning or IsPasssing. No notification was sent for ", alias)
@@ -59,7 +59,7 @@ func (opsgenie *OpsGenieNotifier) Notify(messages Messages) bool {
 	return ok
 }
 
-func (opsgenie *OpsGenieNotifier) CreateAlias(message Message) string {
+func (opsgenie *OpsGenieNotifier) createAlias(message Message) string {
 	incidentKey := message.Node
 	if message.ServiceId != "" {
 		incidentKey += ":" + message.ServiceId
@@ -68,7 +68,7 @@ func (opsgenie *OpsGenieNotifier) CreateAlias(message Message) string {
 	return incidentKey
 }
 
-func (opsgenie *OpsGenieNotifier) CreateAlert(alertCli *ogcli.OpsGenieAlertClient, message string, content string, alias string) bool {
+func (opsgenie *OpsGenieNotifier) createAlert(alertCli *ogcli.OpsGenieAlertClient, message string, content string, alias string) bool {
 	log.Debug(fmt.Sprintf("OpsGenieAlertClient.CreateAlert alias: %s", alias))
 
 	req := alerts.CreateAlertRequest{
@@ -93,7 +93,7 @@ func (opsgenie *OpsGenieNotifier) CreateAlert(alertCli *ogcli.OpsGenieAlertClien
 	return true
 }
 
-func (opsgenie *OpsGenieNotifier) CloseAlert(alertCli *ogcli.OpsGenieAlertClient, alias string) bool {
+func (opsgenie *OpsGenieNotifier) closeAlert(alertCli *ogcli.OpsGenieAlertClient, alias string) bool {
 	log.Debug(fmt.Sprintf("OpsGenieAlertClient.CloseAlert alias: %s", alias))
 	req := alerts.CloseAlertRequest{
 		Alias:  alias,

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -69,6 +69,8 @@ func (opsgenie *OpsGenieNotifier) CreateAlias(message Message) string {
 }
 
 func (opsgenie *OpsGenieNotifier) CreateAlert(alertCli *ogcli.OpsGenieAlertClient, message string, content string, alias string) bool {
+	log.Debug(fmt.Sprintf("OpsGenieAlertClient.CreateAlert alias: %s", alias))
+
 	req := alerts.CreateAlertRequest{
 		Message:     message,
 		Description: content,
@@ -80,9 +82,9 @@ func (opsgenie *OpsGenieNotifier) CreateAlert(alertCli *ogcli.OpsGenieAlertClien
 
 	if alertErr != nil {
 		if response == nil {
-			log.Warn("Opsgenie notification trouble", alertErr)
+			log.Warn("Opsgenie notification trouble. ", alertErr)
 		} else {
-			log.Warn("Opsgenie notification trouble.", response.Status)
+			log.Warn("Opsgenie notification trouble. ", response.Status)
 		}
 		return false
 	}
@@ -92,6 +94,7 @@ func (opsgenie *OpsGenieNotifier) CreateAlert(alertCli *ogcli.OpsGenieAlertClien
 }
 
 func (opsgenie *OpsGenieNotifier) CloseAlert(alertCli *ogcli.OpsGenieAlertClient, alias string) bool {
+	log.Debug(fmt.Sprintf("OpsGenieAlertClient.CloseAlert alias: %s", alias))
 	req := alerts.CloseAlertRequest{
 		Alias:  alias,
 		Source: "consul",
@@ -100,9 +103,9 @@ func (opsgenie *OpsGenieNotifier) CloseAlert(alertCli *ogcli.OpsGenieAlertClient
 
 	if alertErr != nil {
 		if response == nil {
-			log.Warn("Opsgenie notification trouble", alertErr)
+			log.Warn("Opsgenie notification trouble. ", alertErr)
 		} else {
-			log.Warn("Opsgenie notification trouble.", response.Status)
+			log.Warn("Opsgenie notification trouble. ", response.Status)
 		}
 		return false
 	}


### PR DESCRIPTION
This changes the opsgenie so that opsgenie can auto-close alerts also (instead of opening new alerts also on state changes to PASSING).

It uses the alias feature of the opsgenie api to match new notifications to existing alerts, and also now makes a CloseAlert call instead of CreateAlert when the the service is recovering.

Also a minor fix required to build the Docker image is included; download URLs for consul had changed.

This is my first time writing go code, so let me know if I've done something bad.