### PR TITLE
Improved HipChat notifier documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,16 +212,19 @@ prefix: `consul-alerts/config/notifiers/hipchat/`
 
 | key          | description                                               |
 |--------------|-----------------------------------------------------------|
-| enabled      | Enable the Hipchat notifier. [Default: false]             |
+| enabled      | Enable the HipChat notifier. [Default: false]             |
 | from         | The name to send notifications as  (optional)             |
 | cluster-name | The name of the cluster. [Default: "Consul Alerts"]       |
-| base-url     | HipChat base url [Default: "https://api.hipchat.com/v2/"] |
+| base-url     | HipChat base url [Default: `https://api.hipchat.com/v2/`] |
 | room-id      | The room to post to                  (mandatory)          |
 | auth-token   | Authentication token                 (mandatory)          |
 
 The `auth-token` needs to be a room notification token for the `room-id`
 being posted to. 
 See [HipChat API docs](https://developer.atlassian.com/hipchat/guide/hipchat-rest-api).
+
+The default `base-url` works for HipChat-hosted rooms. You only need to
+override it if you are running your own server.
 
 #### OpsGenie
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ prefix: `consul-alerts/config/notifiers/pagerduty/`
 | client-name | The monitoring client name                      |
 | client-url  | The monitoring client url                       |
 
-#### Hipchat
+#### HipChat
 
 To enable HipChat builtin notifier, set
 `consul-alerts/config/notifiers/hipchat/enabled` to `true`. Hipchat details
@@ -210,14 +210,18 @@ needs to be configured.
 
 prefix: `consul-alerts/config/notifiers/hipchat/`
 
-| key          | description                                         |
-|--------------|-----------------------------------------------------|
-| enabled      | Enable the Hipchat notifier. [Default: false]       |
-| from         | The name to send notifications as                   |
-| cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
-| base-url     | HipChat base url                                    |
-| room-id      | The room to post to                  (mandatory)    |
-| auth-token   | Authentication token                 (mandatory)    |
+| key          | description                                               |
+|--------------|-----------------------------------------------------------|
+| enabled      | Enable the Hipchat notifier. [Default: false]             |
+| from         | The name to send notifications as  (optional)             |
+| cluster-name | The name of the cluster. [Default: "Consul Alerts"]       |
+| base-url     | HipChat base url [Default: "https://api.hipchat.com/v2/"] |
+| room-id      | The room to post to                  (mandatory)          |
+| auth-token   | Authentication token                 (mandatory)          |
+
+The `auth-token` needs to be a room notification token for the `room-id`
+being posted to. 
+See [HipChat API docs](https://developer.atlassian.com/hipchat/guide/hipchat-rest-api).
 
 #### OpsGenie
 


### PR DESCRIPTION
Prompted by #103, some additions to the doco for the HipChat notifier so it is clear that the auth token needs to be a room notification token for the room the notifications are being sent to. Also that there is a default value for the base URL.