### PR TITLE
Fixes AcalephStorage/consul-alerts#112.

### DIFF
--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
+var sendMail = smtp.SendMail
+
 type EmailNotifier struct {
 	ClusterName string
 	Template    string
@@ -90,8 +92,15 @@ func (emailNotifier *EmailNotifier) Notify(alerts Messages) bool {
 	msg += body.String()
 
 	addr := fmt.Sprintf("%s:%d", emailNotifier.Url, emailNotifier.Port)
-	auth := smtp.PlainAuth("", emailNotifier.Username, emailNotifier.Password, emailNotifier.Url)
-	if err := smtp.SendMail(addr, auth, emailNotifier.SenderEmail, emailNotifier.Receivers, []byte(msg)); err != nil {
+
+	var auth smtp.Auth
+	if emailNotifier.Username == "" || emailNotifier.Password == "" {
+		auth = nil
+	} else {
+		auth = smtp.PlainAuth("", emailNotifier.Username, emailNotifier.Password, emailNotifier.Url)
+	}
+
+	if err := sendMail(addr, auth, emailNotifier.SenderEmail, emailNotifier.Receivers, []byte(msg)); err != nil {
 		log.Println("Unable to send notification:", err)
 		return false
 	}

--- a/notifier/email-notifier_test.go
+++ b/notifier/email-notifier_test.go
@@ -1,0 +1,53 @@
+package notifier
+
+import (
+	"net/smtp"
+	"testing"
+)
+
+func TestNotify_AuthMustBeNilIfNoUsernameIsProvided(t *testing.T) {
+	auth := notifyAndReturnAuth(t, EmailNotifier{Password: "some password"})
+
+	if auth != nil {
+		t.Error("auth must be nil if username is nil")
+	}
+}
+
+func TestNotify_AuthMustBeNilIfNoPasswordIsProvided(t *testing.T) {
+	auth := notifyAndReturnAuth(t, EmailNotifier{Username: "some username"})
+
+	if auth != nil {
+		t.Error("auth must be nil if password is nil")
+	}
+}
+
+func TestNotify_AuthMustNotBeNilIfUsernameAndPasswordAreProvided(t *testing.T) {
+	auth := notifyAndReturnAuth(t, EmailNotifier{Username: "some username", Password: "some password"})
+
+	if auth == nil {
+		t.Error("auth must not be nil if both username and password are not nil")
+	}
+}
+
+func notifyAndReturnAuth(t *testing.T, notifier EmailNotifier) smtp.Auth {
+	oldSendMail := sendMail
+	defer func() {
+		sendMail = oldSendMail
+	}()
+
+	var passedAuth smtp.Auth
+
+	sendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		passedAuth = a
+		return nil
+	}
+
+	alerts := make(Messages, 0)
+	ret := notifier.Notify(alerts)
+
+	if !ret {
+		t.Error("Notify must return true")
+	}
+
+	return passedAuth
+}


### PR DESCRIPTION
Auth is now passed as nil to smtp.SendMail if either username or password is nil.