### PR TITLE
Initial CONTRIBUTING and CODE_OF_CONDUCT docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+Contributor Code of Conduct
+===========================
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+-	The use of sexualized language or imagery
+-	Personal attacks
+-	Trolling or insulting/derogatory comments
+-	Public or private harassment
+-	Publishing other's private information, such as physical or electronic addresses, without explicit permission
+-	Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at [team@acale.ph](mailto:team@acale.ph). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.3.0, available from http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+Contributing to consul-alerts
+=============================
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to `consul-alerts`. These are just guidelines, not rules, use your best judgment and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+
+-	[Code of Conduct](#code-of-conduct)
+
+[How Can I Contribute?](#how-can-i-contribute)
+
+-	[Reporting Bugs](#reporting-bugs)
+-	[Suggesting Enhancements](#suggesting-enhancements)
+-	[Your First Code Contribution](#your-first-code-contribution)
+
+What should I know before I get started?
+----------------------------------------
+
+### Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+How Can I Contribute?
+---------------------
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for `consul-alerts`. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+Before creating bug reports, please check the project's GitHub issues as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
+
+#### Before Submitting A Bug Report
+
+-	**Perform a cursory search** to see if the problem has already been reported. If it has, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue and provide the following information.
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+-	**Use a clear and descriptive title** for the issue to identify the problem.
+-	**Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started consul-alerts, e.g. which command exactly you used in the terminal, or how you started consul-alerts otherwise. When listing steps, **don't just say what you did, but explain how you did it**.
+-	**Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+-	**Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+-	**Explain which behavior you expected to see instead and why.**
+
+Include details about your configuration and environment:
+
+-	**Which version of consul-alerts are you using?**
+-	**Which version of Consul are you using?**
+-	**What's the name and version of the OS you're using**?
+-	**Are you running consul-alerts in the Cloud or a Virtual Machine?** If so, which Provider or VM software are you using?
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for `consul-alerts`, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Before creating enhancement suggestions, please check GitHub issues as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
+
+#### Before Submitting An Enhancement Suggestion
+
+-	**Perform a issue search** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue and provide the following information:
+
+-	**Use a clear and descriptive title** for the issue to identify the suggestion.
+-	**Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+-	**Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+-	**Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+-	**Explain why this enhancement would be useful** to most consul-alerts users.
+
+### Your First Code Contribution
+
+Unsure where to begin contributing to consul-alerts? Please check our GitHub issues list for Open issues or enhancements.


### PR DESCRIPTION
We’d like to start opening up `consul-alerts` to more contributors to the project.

This is an initial set of documents to outline how to contribute and the community code of conduct. It serves as a start for opening up the project.

Unless there are any strong objections, we’ll merge this PR and can then edit or extend as the community grows.