### PR TITLE
Added config option to send one email per node rather than all nodes in one email

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,19 +151,20 @@ The email and smtp details needs to be configured:
 
 prefix: `consul-alerts/config/notifiers/email/`
 
-| key          | description                                                 |
-|--------------|-------------------------------------------------------------|
-| enabled      | Enable the email notifier. [Default: false]                 |
-| cluster-name | The name of the cluster. [Default: "Consul Alerts"]         |
-| url          | The SMTP server url                                         |
-| port         | The SMTP server port                                        |
-| username     | The SMTP username                                           |
-| password     | The SMTP password                                           |
-| sender-alias | The sender alias. [Default: "Consul Alerts"]                |
-| sender-email | The sender email                                            |
-| receivers    | The emails of the receivers. JSON array of string           |
-| template     | Path to custom email template. [Default: internal template] |
-| one-per-alert| Whether to send one email per node [Default: false]         |
+| key          | description                                                                      |
+|--------------|----------------------------------------------------------------------------------|
+| enabled      | Enable the email notifier. [Default: false]                                      |
+| cluster-name | The name of the cluster. [Default: "Consul Alerts"]                              |
+| url          | The SMTP server url                                                              |
+| port         | The SMTP server port                                                             |
+| username     | The SMTP username                                                                |
+| password     | The SMTP password                                                                |
+| sender-alias | The sender alias. [Default: "Consul Alerts"]                                     |
+| sender-email | The sender email                                                                 |
+| receivers    | The emails of the receivers. JSON array of string                                |
+| template     | Path to custom email template. [Default: internal template]                      |
+| one-per-alert| Whether to send one email per alert [Default: false]                             |
+| one-per-node | Whether to send one email per node [Default: false] (overriden by one-per-alert) |
 
 The template can be any go html template. An `EmailData` instance will be passed to the template.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ prefix: `consul-alerts/config/notifiers/email/`
 | sender-email | The sender email                                            |
 | receivers    | The emails of the receivers. JSON array of string           |
 | template     | Path to custom email template. [Default: internal template] |
+| one-per-alert| Whether to send one email per node [Default: false]         |
 
 The template can be any go html template. An `EmailData` instance will be passed to the template.
 

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -205,6 +205,7 @@ func builtinNotifiers() []notifier.Notifier {
 			Template:    emailConfig.Template,
 			ClusterName: emailConfig.ClusterName,
 			NotifName:   "email",
+			OnePerAlert: emailConfig.OnePerAlert,
 		}
 		notifiers = append(notifiers, emailNotifier)
 	}

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -206,6 +206,7 @@ func builtinNotifiers() []notifier.Notifier {
 			ClusterName: emailConfig.ClusterName,
 			NotifName:   "email",
 			OnePerAlert: emailConfig.OnePerAlert,
+			OnePerNode:  emailConfig.OnePerNode,
 		}
 		notifiers = append(notifiers, emailNotifier)
 	}

--- a/consul/client.go
+++ b/consul/client.go
@@ -109,6 +109,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.Email.Url, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/email/username":
 				valErr = loadCustomValue(&config.Notifiers.Email.Username, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/email/one-per-alert":
+				valErr = loadCustomValue(&config.Notifiers.Email.OnePerAlert, val, ConfigTypeBool)
 
 			// log notifier config
 			case "consul-alerts/config/notifiers/log/enabled":

--- a/consul/client.go
+++ b/consul/client.go
@@ -111,6 +111,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.Email.Username, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/email/one-per-alert":
 				valErr = loadCustomValue(&config.Notifiers.Email.OnePerAlert, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/email/one-per-node":
+				valErr = loadCustomValue(&config.Notifiers.Email.OnePerNode, val, ConfigTypeBool)
 
 			// log notifier config
 			case "consul-alerts/config/notifiers/log/enabled":

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -68,6 +68,7 @@ type EmailNotifierConfig struct {
 	SenderEmail string
 	Receivers   []string
 	Template    string
+	OnePerAlert bool
 }
 
 type LogNotifierConfig struct {

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -69,6 +69,7 @@ type EmailNotifierConfig struct {
 	Receivers   []string
 	Template    string
 	OnePerAlert bool
+	OnePerNode  bool
 }
 
 type LogNotifierConfig struct {

--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -63,9 +63,12 @@ func (emailNotifier *EmailNotifier) Notify(alerts Messages) bool {
 		emailDataList = []EmailData{}
 		for nodeName, checks := range nodeMap {
 			singleNodeMap := mapByNodes(checks)
-			nodeStatus, nodePassing, nodeWarnings, nodeFailures := alerts.Summary()
+			nodeStatus, nodePassing, nodeWarnings, nodeFailures := checks.Summary()
+
+			nodeClusterName := emailNotifier.ClusterName + " " + nodeName
+
 			e := EmailData{
-				ClusterName:  nodeName,
+				ClusterName:  nodeClusterName,
 				SystemStatus: nodeStatus,
 				FailCount:    nodeFailures,
 				WarnCount:    nodeWarnings,
@@ -115,7 +118,7 @@ func (emailNotifier *EmailNotifier) Notify(alerts Messages) bool {
 
 		msg := ""
 		msg += fmt.Sprintf("From: \"%s\" <%s>\n", emailNotifier.SenderAlias, emailNotifier.SenderEmail)
-		msg += fmt.Sprintf("Subject: %s is %s\n", emailNotifier.ClusterName, e.SystemStatus)
+		msg += fmt.Sprintf("Subject: %s is %s\n", e.ClusterName, e.SystemStatus)
 		msg += "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 		msg += body.String()
 

--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -155,7 +155,7 @@ Content-Type: text/html; charset="UTF-8";
 			emailNotifier.SenderEmail,
 			strings.Join(emailNotifier.Receivers, ", "),
 			emailNotifier.ClusterName,
-			overAllStatus,
+			e.SystemStatus,
 			body.String())
 
 		addr := fmt.Sprintf("%s:%d", emailNotifier.Url, emailNotifier.Port)


### PR DESCRIPTION
Functionality should remain unchanged unless the new config option is used.

Our sysadmins weren't happy with receiving emails with info about multiple nodes in, so added a little bit of logic to separate it out.

Any thoughts / comments appreciated as I'm still trying to learn Golang

Cheers,