### PR TITLE
Install alpine-sdk for build in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ ENV GOPATH /go
 
 RUN mkdir -p /go && \
     apk update && \
-    apk add bash ca-certificates git go && \
+    apk add bash ca-certificates git go alpine-sdk && \
     go get -v github.com/AcalephStorage/consul-alerts && \
     mv /go/bin/consul-alerts /bin && \
     go get -v github.com/hashicorp/consul && \
     mv /go/bin/consul /bin && \
     rm -rf /go && \
-    apk del --purge go git && \
+    apk del --purge go git alpine-sdk && \
     rm -rf /var/cache/apk/*
 
 EXPOSE 9000


### PR DESCRIPTION
The Docker image currently doesn't build in `master` because `runtime/cgo` (which seems to be at the end of a dependency chain started by a bunch of AWS packages?) needs `gcc` installed, which doesn't exist in the default Alpine Linux package.  This patch installs it in the Docker image before compilation of `consul-alerts` and then uninstalls it to keep the image size reasonable.