### PR TITLE
Add VictorOps notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,21 @@ prefix: `consul-alerts/config/notifiers/awssns/`
 | region       | AWS Region                           (mandatory)    |
 | topic-arn    | Topic ARN to publish to.             (mandatory)    |
 
+#### VictorOps
+
+To enable the VictorOps builtin notifier, set
+`consul-alerts/config/notifiers/victorops/enabled` to `true`. VictorOps details
+needs to be configured.
+
+prefix: `consul-alerts/config/notifiers/victorops/`
+
+| key          | description                                         |
+|--------------|-----------------------------------------------------|
+| enabled      | Enable the VictorOps notifier. [Default: false]     |
+| api-key      | API Key                              (mandatory)    |
+| routing-key  | Routing Key                          (mandatory)    |
+
+
 Health Check via API
 --------------------
 

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -192,6 +192,7 @@ func builtinNotifiers() []notifier.Notifier {
 	hipchatConfig := consulClient.HipChatConfig()
 	opsgenieConfig := consulClient.OpsGenieConfig()
 	awssnsConfig := consulClient.AwsSnsConfig()
+	victoropsConfig := consulClient.VictorOpsConfig()
 
 	notifiers := []notifier.Notifier{}
 	if emailConfig.Enabled {
@@ -277,6 +278,14 @@ func builtinNotifiers() []notifier.Notifier {
 			NotifName: "awssns",
 		}
 		notifiers = append(notifiers, awssnsNotifier)
+	}
+	if victoropsConfig.Enabled {
+		victoropsNotifier := &notifier.VictorOpsNotifier{
+			APIKey:     victoropsConfig.APIKey,
+			RoutingKey: victoropsConfig.RoutingKey,
+			NotifName:  "victorops",
+		}
+		notifiers = append(notifiers, victoropsNotifier)
 	}
 
 	return notifiers

--- a/consul/client.go
+++ b/consul/client.go
@@ -192,6 +192,13 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/awssns/topic-arn":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.TopicArn, val, ConfigTypeString)
 
+			// VictorOps notfier config
+			case "consul-alerts/config/notifiers/victorops/enabled":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.Enabled, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/victorops/api-key":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.APIKey, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/victorops/routing-key":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.RoutingKey, val, ConfigTypeString)
 			}
 
 			if valErr != nil {
@@ -425,6 +432,10 @@ func (c *ConsulAlertClient) OpsGenieConfig() *OpsGenieNotifierConfig {
 
 func (c *ConsulAlertClient) AwsSnsConfig() *AwsSnsNotifierConfig {
 	return c.config.Notifiers.AwsSns
+}
+
+func (c *ConsulAlertClient) VictorOpsConfig() *VictorOpsNotifierConfig {
+	return c.config.Notifiers.VictorOps
 }
 
 func (c *ConsulAlertClient) registerHealthCheck(key string, health *Check) {

--- a/consul/client.go
+++ b/consul/client.go
@@ -434,6 +434,7 @@ func (c *ConsulAlertClient) AwsSnsConfig() *AwsSnsNotifierConfig {
 	return c.config.Notifiers.AwsSns
 }
 
+// VictorOpsConfig provides configuration for the VictorOps integration
 func (c *ConsulAlertClient) VictorOpsConfig() *VictorOpsNotifierConfig {
 	return c.config.Notifiers.VictorOps
 }

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -126,6 +126,7 @@ type AwsSnsNotifierConfig struct {
 	TopicArn string
 }
 
+// VictorOpsNotifierConfig provides configuration options for VictorOps notifier
 type VictorOpsNotifierConfig struct {
 	Enabled    bool
 	APIKey     string

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -54,6 +54,7 @@ type NotifiersConfig struct {
 	HipChat   *HipChatNotifierConfig
 	OpsGenie  *OpsGenieNotifierConfig
 	AwsSns    *AwsSnsNotifierConfig
+	VictorOps *VictorOpsNotifierConfig
 	Custom    []string
 }
 
@@ -125,6 +126,12 @@ type AwsSnsNotifierConfig struct {
 	TopicArn string
 }
 
+type VictorOpsNotifierConfig struct {
+	Enabled    bool
+	APIKey     string
+	RoutingKey string
+}
+
 type Status struct {
 	Current          string
 	CurrentTimestamp time.Time
@@ -156,6 +163,7 @@ type Consul interface {
 	HipChatConfig() *HipChatNotifierConfig
 	OpsGenieConfig() *OpsGenieNotifierConfig
 	AwsSnsConfig() *AwsSnsNotifierConfig
+	VictorOpsConfig() *VictorOpsNotifierConfig
 
 	CheckChangeThreshold() int
 	UpdateCheckData()
@@ -229,6 +237,10 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		Enabled: false,
 	}
 
+	victorOps := &VictorOpsNotifierConfig{
+		Enabled: false,
+	}
+
 	notifiers := &NotifiersConfig{
 		Email:     email,
 		Log:       log,
@@ -238,6 +250,7 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		HipChat:   hipchat,
 		OpsGenie:  opsgenie,
 		AwsSns:    awsSns,
+		VictorOps: victorOps,
 		Custom:    []string{},
 	}
 

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,3 +1,4 @@
+// Package notifier manages notifications for consul-alerts
 package notifier
 
 import "time"

--- a/notifier/victorops-notifier.go
+++ b/notifier/victorops-notifier.go
@@ -1,0 +1,129 @@
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+type VictorOpsNotifier struct {
+	NotifName  string
+	APIKey     string
+	RoutingKey string
+}
+
+type VictorOpsEvent struct {
+	// Explicitly listed by http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/
+	MessageType       string `json:"message_type"`
+	EntityId          string `json:"entity_id"`
+	Timestamp         uint32 `json:"timestamp"`
+	StateMessage      string `json:"state_message"`
+	MonitoringTool    string `json:"monitoring_tool"`
+	EntityDisplayName string `json:"entity_display_name"`
+
+	// Helpful fields from http://victorops.force.com/knowledgebase/articles/Getting_Started/Incident-Fields-Glossary/?l=en_US&fs=RelatedArticle
+	HostName    string `json:"host_name"`
+	MonitorName string `json:"monitor_name"`
+
+	// VictorOps lets you add arbitrary fields to help custom notification logic, so we'll set
+	// node, service, service ID, check, and check ID
+	ConsulNode      string `json:"consul_node"`
+	ConsulService   string `json:"consul_service,omitempty"`
+	ConsulServiceId string `json:"consul_service_id,omitempty"`
+	ConsulCheck     string `json:"consul_check"`
+	ConsulCheckId   string `json:"consul_check_id"`
+}
+
+const MONITORING_TOOL_NAME string = "consul"
+const API_ENDPOINT_TEMPLATE string = "https://alert.victorops.com/integrations/generic/20131114/alert/%s/%s"
+
+// NotifierName provides name for notifier selection
+func (vo *VictorOpsNotifier) NotifierName() string {
+	return vo.NotifName
+}
+
+//Notify sends messages to the endpoint notifier
+
+func (vo *VictorOpsNotifier) Notify(messages Messages) bool {
+	var endpoint string = fmt.Sprintf(API_ENDPOINT_TEMPLATE, vo.APIKey, vo.RoutingKey)
+
+	var ok bool = true
+
+	for _, message := range messages {
+		var entityId string = fmt.Sprintf("%s:", message.Node)
+		var entityDisplayName string = entityId
+
+		// This might be a node level check without an explicit service
+		if message.ServiceId == "" {
+			entityId += message.CheckId
+			entityDisplayName += message.Check
+		} else {
+			entityId += message.ServiceId
+			entityDisplayName += message.Service
+		}
+
+		var messageType string = ""
+
+		switch {
+		case message.IsCritical():
+			messageType = "CRITICAL"
+		case message.IsWarning():
+			messageType = "WARNING"
+		case message.IsPassing():
+			messageType = "RECOVERY"
+		default:
+			log.Warn(fmt.Sprintf("Message with status %s was neither critical, warning, nor passing, reporting to VictorOps as INFO", message.Status))
+			messageType = "INFO"
+		}
+
+		// VictorOps automatically displays the entity display name in notifications and page SMSs / emails,
+		// so for brevity we don't repeat it in the "StateMessage" field
+		var stateMessage string = fmt.Sprintf("%s: %s\n%s", messageType, message.Notes, message.Output)
+
+		event := VictorOpsEvent{
+			MessageType:       messageType,
+			EntityId:          entityId,
+			Timestamp:         uint32(message.Timestamp.Unix()),
+			StateMessage:      stateMessage,
+			MonitoringTool:    MONITORING_TOOL_NAME,
+			EntityDisplayName: entityDisplayName,
+
+			HostName:    message.Node,
+			MonitorName: message.Check,
+
+			ConsulNode:      message.Node,
+			ConsulService:   message.Service,
+			ConsulServiceId: message.ServiceId,
+			ConsulCheck:     message.Check,
+			ConsulCheckId:   message.CheckId,
+		}
+
+		eventJSON, jsonError := json.Marshal(event)
+
+		if jsonError != nil {
+			ok = false
+			log.Error("Error JSON-ifying VictorOps alert. ", jsonError)
+			continue
+		}
+
+		response, httpError := http.Post(endpoint, "application/json", bytes.NewBuffer(eventJSON))
+
+		if httpError != nil {
+			ok = false
+			log.Error("Error hitting VictorOps API. ", httpError)
+			continue
+		}
+
+		if response.StatusCode != 200 {
+			ok = false
+			log.Error(fmt.Sprintf("Expected VictorOps endpoint to return 200, but it returned %d"), response.StatusCode)
+			continue
+		}
+	}
+
+	log.Println("VictorOps notification sent.")
+	return ok
+}


### PR DESCRIPTION
Adds a VictorOps notifier by directly hitting the VictorOps API (documentation at http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/).  Fulfills the feature request at https://github.com/AcalephStorage/consul-alerts/issues/71.  This will compile and run locally fine, but note that Docker images don't seem to currently be building in master (nor in this PR) because of an unrelated missing build dependency; I've submitted a separate PR at https://github.com/AcalephStorage/consul-alerts/pull/128 to fix that.