### PR TITLE
Configure consul-alerts options by using JSON file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.5
 MAINTAINER Acaleph <admin@acale.ph>
 RUN apt-get update && apt-get install -y unzip --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN (curl -OL https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip &&\
-unzip 0.5.2_linux_amd64.zip &&\
+RUN (curl -OL https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip &&\
+unzip consul_0.5.2_linux_amd64.zip &&\
 chmod +x consul &&\
 mv consul /bin/ &&\
-rm 0.5.2_linux_amd64.zip)
+rm consul_0.5.2_linux_amd64.zip)
 
 ADD . /go/src/github.com/AcalephStorage/consul-alerts
 RUN go get github.com/AcalephStorage/consul-alerts

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ ENV GOPATH /go
 
 RUN mkdir -p /go && \
     apk update && \
-    apk add bash ca-certificates git go && \
+    apk add bash ca-certificates git go alpine-sdk && \
     go get -v github.com/AcalephStorage/consul-alerts && \
     mv /go/bin/consul-alerts /bin && \
     go get -v github.com/hashicorp/consul && \
     mv /go/bin/consul /bin && \
     rm -rf /go && \
-    apk del --purge go git && \
+    apk del --purge go git alpine-sdk && \
     rm -rf /var/cache/apk/*
 
 EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -327,6 +327,21 @@ prefix: `consul-alerts/config/notifiers/awssns/`
 | region       | AWS Region                           (mandatory)    |
 | topic-arn    | Topic ARN to publish to.             (mandatory)    |
 
+#### VictorOps
+
+To enable the VictorOps builtin notifier, set
+`consul-alerts/config/notifiers/victorops/enabled` to `true`. VictorOps details
+needs to be configured.
+
+prefix: `consul-alerts/config/notifiers/victorops/`
+
+| key          | description                                         |
+|--------------|-----------------------------------------------------|
+| enabled      | Enable the VictorOps notifier. [Default: false]     |
+| api-key      | API Key                              (mandatory)    |
+| routing-key  | Routing Key                          (mandatory)    |
+
+
 Health Check via API
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -208,18 +208,20 @@ The email and smtp details needs to be configured:
 
 prefix: `consul-alerts/config/notifiers/email/`
 
-| key          | description                                                 |
-|--------------|-------------------------------------------------------------|
-| enabled      | Enable the email notifier. [Default: false]                 |
-| cluster-name | The name of the cluster. [Default: "Consul Alerts"]         |
-| url          | The SMTP server url                                         |
-| port         | The SMTP server port                                        |
-| username     | The SMTP username                                           |
-| password     | The SMTP password                                           |
-| sender-alias | The sender alias. [Default: "Consul Alerts"]                |
-| sender-email | The sender email                                            |
-| receivers    | The emails of the receivers. JSON array of string           |
-| template     | Path to custom email template. [Default: internal template] |
+| key          | description                                                                      |
+|--------------|----------------------------------------------------------------------------------|
+| enabled      | Enable the email notifier. [Default: false]                                      |
+| cluster-name | The name of the cluster. [Default: "Consul Alerts"]                              |
+| url          | The SMTP server url                                                              |
+| port         | The SMTP server port                                                             |
+| username     | The SMTP username                                                                |
+| password     | The SMTP password                                                                |
+| sender-alias | The sender alias. [Default: "Consul Alerts"]                                     |
+| sender-email | The sender email                                                                 |
+| receivers    | The emails of the receivers. JSON array of string                                |
+| template     | Path to custom email template. [Default: internal template]                      |
+| one-per-alert| Whether to send one email per alert [Default: false]                             |
+| one-per-node | Whether to send one email per node [Default: false] (overriden by one-per-alert) |
 
 The template can be any go html template. An `EmailData` instance will be passed to the template.
 

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -192,6 +192,7 @@ func builtinNotifiers() []notifier.Notifier {
 	hipchatConfig := consulClient.HipChatConfig()
 	opsgenieConfig := consulClient.OpsGenieConfig()
 	awssnsConfig := consulClient.AwsSnsConfig()
+	victoropsConfig := consulClient.VictorOpsConfig()
 
 	notifiers := []notifier.Notifier{}
 	if emailConfig.Enabled {
@@ -277,6 +278,14 @@ func builtinNotifiers() []notifier.Notifier {
 			NotifName: "awssns",
 		}
 		notifiers = append(notifiers, awssnsNotifier)
+	}
+	if victoropsConfig.Enabled {
+		victoropsNotifier := &notifier.VictorOpsNotifier{
+			APIKey:     victoropsConfig.APIKey,
+			RoutingKey: victoropsConfig.RoutingKey,
+			NotifName:  "victorops",
+		}
+		notifiers = append(notifiers, victoropsNotifier)
 	}
 
 	return notifiers

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -205,6 +205,8 @@ func builtinNotifiers() []notifier.Notifier {
 			Template:    emailConfig.Template,
 			ClusterName: emailConfig.ClusterName,
 			NotifName:   "email",
+			OnePerAlert: emailConfig.OnePerAlert,
+			OnePerNode:  emailConfig.OnePerNode,
 		}
 		notifiers = append(notifiers, emailNotifier)
 	}

--- a/consul/client.go
+++ b/consul/client.go
@@ -192,6 +192,13 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/awssns/topic-arn":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.TopicArn, val, ConfigTypeString)
 
+			// VictorOps notfier config
+			case "consul-alerts/config/notifiers/victorops/enabled":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.Enabled, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/victorops/api-key":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.APIKey, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/victorops/routing-key":
+				valErr = loadCustomValue(&config.Notifiers.VictorOps.RoutingKey, val, ConfigTypeString)
 			}
 
 			if valErr != nil {
@@ -425,6 +432,11 @@ func (c *ConsulAlertClient) OpsGenieConfig() *OpsGenieNotifierConfig {
 
 func (c *ConsulAlertClient) AwsSnsConfig() *AwsSnsNotifierConfig {
 	return c.config.Notifiers.AwsSns
+}
+
+// VictorOpsConfig provides configuration for the VictorOps integration
+func (c *ConsulAlertClient) VictorOpsConfig() *VictorOpsNotifierConfig {
+	return c.config.Notifiers.VictorOps
 }
 
 func (c *ConsulAlertClient) registerHealthCheck(key string, health *Check) {

--- a/consul/client.go
+++ b/consul/client.go
@@ -109,6 +109,10 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.Email.Url, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/email/username":
 				valErr = loadCustomValue(&config.Notifiers.Email.Username, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/email/one-per-alert":
+				valErr = loadCustomValue(&config.Notifiers.Email.OnePerAlert, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/email/one-per-node":
+				valErr = loadCustomValue(&config.Notifiers.Email.OnePerNode, val, ConfigTypeBool)
 
 			// log notifier config
 			case "consul-alerts/config/notifiers/log/enabled":

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -68,6 +68,8 @@ type EmailNotifierConfig struct {
 	SenderEmail string
 	Receivers   []string
 	Template    string
+	OnePerAlert bool
+	OnePerNode  bool
 }
 
 type LogNotifierConfig struct {

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -54,6 +54,7 @@ type NotifiersConfig struct {
 	HipChat   *HipChatNotifierConfig
 	OpsGenie  *OpsGenieNotifierConfig
 	AwsSns    *AwsSnsNotifierConfig
+	VictorOps *VictorOpsNotifierConfig
 	Custom    []string
 }
 
@@ -125,6 +126,13 @@ type AwsSnsNotifierConfig struct {
 	TopicArn string
 }
 
+// VictorOpsNotifierConfig provides configuration options for VictorOps notifier
+type VictorOpsNotifierConfig struct {
+	Enabled    bool
+	APIKey     string
+	RoutingKey string
+}
+
 type Status struct {
 	Current          string
 	CurrentTimestamp time.Time
@@ -156,6 +164,7 @@ type Consul interface {
 	HipChatConfig() *HipChatNotifierConfig
 	OpsGenieConfig() *OpsGenieNotifierConfig
 	AwsSnsConfig() *AwsSnsNotifierConfig
+	VictorOpsConfig() *VictorOpsNotifierConfig
 
 	CheckChangeThreshold() int
 	UpdateCheckData()
@@ -229,6 +238,10 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		Enabled: false,
 	}
 
+	victorOps := &VictorOpsNotifierConfig{
+		Enabled: false,
+	}
+
 	notifiers := &NotifiersConfig{
 		Email:     email,
 		Log:       log,
@@ -238,6 +251,7 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		HipChat:   hipchat,
 		OpsGenie:  opsgenie,
 		AwsSns:    awsSns,
+		VictorOps: victorOps,
 		Custom:    []string{},
 	}
 

--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -24,6 +24,8 @@ type EmailNotifier struct {
 	SenderEmail string
 	Receivers   []string
 	NotifName   string
+	OnePerAlert bool
+	OnePerNode  bool
 }
 
 type EmailData struct {
@@ -58,35 +60,90 @@ func (emailNotifier *EmailNotifier) Notify(alerts Messages) bool {
 	overAllStatus, pass, warn, fail := alerts.Summary()
 	nodeMap := mapByNodes(alerts)
 
-	e := EmailData{
-		ClusterName:  emailNotifier.ClusterName,
-		SystemStatus: overAllStatus,
-		FailCount:    fail,
-		WarnCount:    warn,
-		PassCount:    pass,
-		Nodes:        nodeMap,
-	}
+	var emailDataList []EmailData
 
-	var tmpl *template.Template
-	var err error
-	if emailNotifier.Template == "" {
-		tmpl, err = template.New("base").Parse(defaultTemplate)
+	if emailNotifier.OnePerAlert {
+		log.Println("Going to send one email per alert")
+		emailDataList = []EmailData{}
+		for _, check := range alerts {
+
+			singleAlertChecks := make(Messages, 0)
+			singleAlertChecks = append(singleAlertChecks, check)
+			singleAlertMap := mapByNodes(singleAlertChecks)
+
+			alertStatus, alertPassing, alertWarnings, alertFailures := singleAlertChecks.Summary()
+
+			alertClusterName := emailNotifier.ClusterName + " " + check.Node + " - " + check.CheckId
+
+			e := EmailData{
+				ClusterName:  alertClusterName,
+				SystemStatus: alertStatus,
+				FailCount:    alertFailures,
+				WarnCount:    alertWarnings,
+				PassCount:    alertPassing,
+				Nodes:        singleAlertMap,
+			}
+			emailDataList = append(emailDataList, e)
+		}
+	} else if emailNotifier.OnePerNode {
+		log.Println("Going to send one email per node")
+		emailDataList = []EmailData{}
+		for nodeName, checks := range nodeMap {
+			singleNodeMap := mapByNodes(checks)
+			nodeStatus, nodePassing, nodeWarnings, nodeFailures := checks.Summary()
+
+			nodeClusterName := emailNotifier.ClusterName + " " + nodeName
+
+			e := EmailData{
+				ClusterName:  nodeClusterName,
+				SystemStatus: nodeStatus,
+				FailCount:    nodeFailures,
+				WarnCount:    nodeWarnings,
+				PassCount:    nodePassing,
+				Nodes:        singleNodeMap,
+			}
+			emailDataList = append(emailDataList, e)
+		}
 	} else {
-		tmpl, err = template.ParseFiles(emailNotifier.Template)
+		log.Println("Going to send one email for many alerts")
+		e := EmailData{
+			ClusterName:  emailNotifier.ClusterName,
+			SystemStatus: overAllStatus,
+			FailCount:    fail,
+			WarnCount:    warn,
+			PassCount:    pass,
+			Nodes:        nodeMap,
+		}
+
+		emailDataList = []EmailData{e}
 	}
 
-	if err != nil {
-		log.Println("Template error, unable to send email notification: ", err)
-		return false
-	}
+	success := true
 
-	var body bytes.Buffer
-	if err := tmpl.Execute(&body, e); err != nil {
-		log.Println("Template error, unable to send email notification: ", err)
-		return false
-	}
+	for _, e := range emailDataList {
 
-	msg := fmt.Sprintf(`From: "%s" <%s>
+		var tmpl *template.Template
+		var err error
+		if emailNotifier.Template == "" {
+			tmpl, err = template.New("base").Parse(defaultTemplate)
+		} else {
+			tmpl, err = template.ParseFiles(emailNotifier.Template)
+		}
+
+		if err != nil {
+			log.Println("Template error, unable to send email notification: ", err)
+			success = false
+			continue
+		}
+
+		var body bytes.Buffer
+		if err := tmpl.Execute(&body, e); err != nil {
+			log.Println("Template error, unable to send email notification: ", err)
+			success = false
+			continue
+		}
+
+		msg := fmt.Sprintf(`From: "%s" <%s>
 To: %s
 Subject: %s is %s
 MIME-version: 1.0;
@@ -94,21 +151,24 @@ Content-Type: text/html; charset="UTF-8";
 
 %s
 `,
-		emailNotifier.SenderAlias,
-		emailNotifier.SenderEmail,
-		strings.Join(emailNotifier.Receivers, ", "),
-		emailNotifier.ClusterName,
-		overAllStatus,
-		body.String())
+			emailNotifier.SenderAlias,
+			emailNotifier.SenderEmail,
+			strings.Join(emailNotifier.Receivers, ", "),
+			emailNotifier.ClusterName,
+			e.SystemStatus,
+			body.String())
 
-	addr := fmt.Sprintf("%s:%d", emailNotifier.Url, emailNotifier.Port)
-	auth := smtp.PlainAuth("", emailNotifier.Username, emailNotifier.Password, emailNotifier.Url)
-	if err := sendMail(addr, auth, emailNotifier.SenderEmail, emailNotifier.Receivers, []byte(msg)); err != nil {
-		log.Println("Unable to send notification:", err)
-		return false
+		addr := fmt.Sprintf("%s:%d", emailNotifier.Url, emailNotifier.Port)
+		auth := smtp.PlainAuth("", emailNotifier.Username, emailNotifier.Password, emailNotifier.Url)
+		if err := sendMail(addr, auth, emailNotifier.SenderEmail, emailNotifier.Receivers, []byte(msg)); err != nil {
+			log.Println("Unable to send notification:", err)
+			continue
+		}
+		log.Println("Email notification sent.")
+		success = success && true
 	}
-	log.Println("Email notification sent.")
-	return true
+
+	return success
 }
 
 func mapByNodes(alerts Messages) map[string]Messages {

--- a/notifier/hipchat-notifier.go
+++ b/notifier/hipchat-notifier.go
@@ -2,7 +2,10 @@ package notifier
 
 import (
 	"fmt"
+	"html"
 	"net/url"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/tbruyelle/hipchat-go/hipchat"
 
@@ -28,11 +31,14 @@ func (notifier *HipChatNotifier) Notify(messages Messages) bool {
 
 	overallStatus, pass, warn, fail := messages.Summary()
 
-	text := fmt.Sprintf(header, notifier.ClusterName, overallStatus, fail, warn, pass)
-
+	text := fmt.Sprintf("%s is <STRONG>%s</STRONG>. Fail: %d, Warn: %d, Pass: %d", notifier.ClusterName, overallStatus, fail, warn, pass)
+	
 	for _, message := range messages {
-		text += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
-		text += fmt.Sprintf("\n%s", message.Output)
+		text += fmt.Sprintf("<BR><STRONG><CODE>%s</CODE></STRONG>:%s:%s is <STRONG>%s</STRONG>.", 
+            message.Node, html.EscapeString(message.Service), html.EscapeString(message.Check), message.Status)
+        if utf8.RuneCountInString(message.Output) > 0 {
+            text += fmt.Sprintf("<BR>%s", strings.Replace(html.EscapeString(strings.TrimSpace(message.Output)), "\n", "<BR>", -1));
+        }
 	}
 
 	level := "green"
@@ -57,12 +63,15 @@ func (notifier *HipChatNotifier) Notify(messages Messages) bool {
 	}
 
 	notifRq := &hipchat.NotificationRequest{
-		From:    from,
-		Message: text,
-		Color:   level,
-		Notify:  true,
+		Color:         level,
+		Message:       text,
+		Notify:        true,
+		MessageFormat: "html",
+		From:          from,
 	}
+	
 	resp, err := client.Room.Notification(notifier.RoomId, notifRq)
+	
 	if err != nil {
 		log.Printf("Error sending notification to hipchat: %s\n", err)
 		log.Printf("Server returns %+v\n", resp)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,3 +1,4 @@
+// Package notifier manages notifications for consul-alerts
 package notifier
 
 import "time"

--- a/notifier/victorops-notifier.go
+++ b/notifier/victorops-notifier.go
@@ -1,0 +1,131 @@
+// Package notifier manages notifications for consul-alerts
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+// VictorOpsNotifier provides configuration options for the VictorOps notifier
+type VictorOpsNotifier struct {
+	NotifName  string
+	APIKey     string
+	RoutingKey string
+}
+
+// VictorOpsEvent represents the options we'll pass to the VictorOps API
+type VictorOpsEvent struct {
+	// Explicitly listed by http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/
+	MessageType       string `json:"message_type"`
+	EntityID          string `json:"entity_id"`
+	Timestamp         uint32 `json:"timestamp"`
+	StateMessage      string `json:"state_message"`
+	MonitoringTool    string `json:"monitoring_tool"`
+	EntityDisplayName string `json:"entity_display_name"`
+
+	// Helpful fields from http://victorops.force.com/knowledgebase/articles/Getting_Started/Incident-Fields-Glossary/?l=en_US&fs=RelatedArticle
+	HostName    string `json:"host_name"`
+	MonitorName string `json:"monitor_name"`
+
+	// VictorOps lets you add arbitrary fields to help custom notification logic, so we'll set
+	// node, service, service ID, check, and check ID
+	ConsulNode      string `json:"consul_node"`
+	ConsulService   string `json:"consul_service,omitempty"`
+	ConsulServiceID string `json:"consul_service_id,omitempty"`
+	ConsulCheck     string `json:"consul_check"`
+	ConsulCheckID   string `json:"consul_check_id"`
+}
+
+const monitoringToolName string = "consul"
+const apiEndpointTemplate string = "https://alert.victorops.com/integrations/generic/20131114/alert/%s/%s"
+
+// NotifierName provides name for notifier selection
+func (vo *VictorOpsNotifier) NotifierName() string {
+	return vo.NotifName
+}
+
+// Notify sends messages to the endpoint notifier
+func (vo *VictorOpsNotifier) Notify(messages Messages) bool {
+	endpoint := fmt.Sprintf(apiEndpointTemplate, vo.APIKey, vo.RoutingKey)
+
+	ok := true
+
+	for _, message := range messages {
+		entityID := fmt.Sprintf("%s:", message.Node)
+		entityDisplayName := entityID
+
+		// This might be a node level check without an explicit service
+		if message.ServiceId == "" {
+			entityID += message.CheckId
+			entityDisplayName += message.Check
+		} else {
+			entityID += message.ServiceId
+			entityDisplayName += message.Service
+		}
+
+		var messageType string
+
+		switch {
+		case message.IsCritical():
+			messageType = "CRITICAL"
+		case message.IsWarning():
+			messageType = "WARNING"
+		case message.IsPassing():
+			messageType = "RECOVERY"
+		default:
+			log.Warn(fmt.Sprintf("Message with status %s was neither critical, warning, nor passing, reporting to VictorOps as INFO", message.Status))
+			messageType = "INFO"
+		}
+
+		// VictorOps automatically displays the entity display name in notifications and page SMSs / emails,
+		// so for brevity we don't repeat it in the "StateMessage" field
+		stateMessage := fmt.Sprintf("%s: %s\n%s", messageType, message.Notes, message.Output)
+
+		event := VictorOpsEvent{
+			MessageType:       messageType,
+			EntityID:          entityID,
+			Timestamp:         uint32(message.Timestamp.Unix()),
+			StateMessage:      stateMessage,
+			MonitoringTool:    monitoringToolName,
+			EntityDisplayName: entityDisplayName,
+
+			HostName:    message.Node,
+			MonitorName: message.Check,
+
+			ConsulNode:      message.Node,
+			ConsulService:   message.Service,
+			ConsulServiceID: message.ServiceId,
+			ConsulCheck:     message.Check,
+			ConsulCheckID:   message.CheckId,
+		}
+
+		eventJSON, jsonError := json.Marshal(event)
+
+		if jsonError != nil {
+			ok = false
+			log.Error("Error JSON-ifying VictorOps alert. ", jsonError)
+			continue
+		}
+
+		response, httpError := http.Post(endpoint, "application/json", bytes.NewBuffer(eventJSON))
+
+		if httpError != nil {
+			ok = false
+			log.Error("Error hitting VictorOps API. ", httpError)
+			continue
+		}
+
+		if response.StatusCode != 200 {
+			ok = false
+			log.Error(fmt.Sprintf("Expected VictorOps endpoint to return 200, but it returned %d"), response.StatusCode)
+			continue
+		}
+	}
+
+	log.Println("VictorOps notification sent.")
+	return ok
+}

--- a/provision/consul-server.conf.j2
+++ b/provision/consul-server.conf.j2
@@ -8,7 +8,7 @@ stop on starting shutdown
 export GOMAXPROCS=`nproc`
 
 # Needed on first server -bootstrap
-exec /usr/local/bin/consul agent -server -bootstrap-expect 3 -config-dir /etc/consul.d -data-dir /var/lib/consul -ui-dir /opt/consul/ui/dist -bind {{ ansible_eth1.ipv4.address }} -client 0.0.0.0
+exec /usr/local/bin/consul agent -server -bootstrap-expect 3 -config-dir /etc/consul.d -data-dir /var/lib/consul -ui-dir /opt/consul/ui -bind {{ ansible_eth1.ipv4.address }} -client 0.0.0.0
 
 respawn
 respawn limit 10 10

--- a/provision/site.yml
+++ b/provision/site.yml
@@ -8,11 +8,11 @@
         update_cache: yes
     - name: Download Consul
       get_url:
-        url: https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
-        dest: /tmp/consul-0.6.0_linux_amd64.zip
+        url: https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip
+        dest: /tmp/consul-0.6.4_linux_amd64.zip
     - name: Unzip Consul
       unarchive:
-        src: /tmp/consul-0.6.0_linux_amd64.zip
+        src: /tmp/consul-0.6.4_linux_amd64.zip
         dest: /usr/local/bin
         copy: no
         group: root
@@ -41,15 +41,15 @@
         mode: 0644
     - name: Download Consul UI
       get_url:
-        url: https://dl.bintray.com/mitchellh/consul/0.6.0_web_ui.zip
-        dest: /tmp/consul-0.6.0_web_ui.zip
+        url: https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_web_ui.zip
+        dest: /tmp/consul-0.6.4_web_ui.zip
     - name: Create consul-ui dir
       file:
         name: /opt/consul/ui
         state: directory
     - name: Unzip Consul-UI
       unarchive:
-        src: /tmp/consul-0.6.0_web_ui.zip
+        src: /tmp/consul-0.6.4_web_ui.zip
         dest: /opt/consul/ui
         copy: no
     - name: Copy the consul server init


### PR DESCRIPTION
I just adapted the code in order to:

- Accept consul-alerts options in JSON config file.
- The options in config file will overwrite the options in command line.

Hope that this one doesn't disturb the current code and is accepted. 

I have tested on our system. It is highly appreciated if anyone can let me know what I need to improve. 

Thank you. 