### PR TITLE
Ensure the cluster name is the one from the individual email

### DIFF
--- a/notifier/email-notifier.go
+++ b/notifier/email-notifier.go
@@ -154,7 +154,7 @@ Content-Type: text/html; charset="UTF-8";
 			emailNotifier.SenderAlias,
 			emailNotifier.SenderEmail,
 			strings.Join(emailNotifier.Receivers, ", "),
-			emailNotifier.ClusterName,
+			e.ClusterName,
 			e.SystemStatus,
 			body.String())
 


### PR DESCRIPTION
Some of the checks change the cluster name to display differing information in the subject line