### PR TITLE
Drop ACL token from logs

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -149,7 +149,6 @@ func daemonMode(arguments map[string]interface{}) {
 
 	hostname, _ := os.Hostname()
 
-	log.Println("Consul ACL Token:", consulAclToken)
 	log.Println("Consul Alerts daemon started")
 	log.Println("Consul Alerts Host:", hostname)
 	log.Println("Consul Agent:", consulAddr)


### PR DESCRIPTION
As suggested in #152, printing ACL token to logs might lead to security issues. In this PR it is removed from the output.