### PR TITLE
Improve checking against blacklist by reducing the number of calls to KV

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -275,10 +275,9 @@ func (c *ConsulAlertClient) UpdateCheckData() {
 		}
 		if settodelete {
 			log.Printf("Reminder %s %s needs to be deleted, stale", node, check)
-		        c.DeleteReminder(node, check)
+			c.DeleteReminder(node, check)
 		}
 	}
-
 
 	for _, health := range healths {
 
@@ -656,26 +655,31 @@ func (c *ConsulAlertClient) GetProfileInfo(node, serviceID, checkID string) (not
 
 // IsBlacklisted gets the blacklist status of check
 func (c *ConsulAlertClient) IsBlacklisted(check *Check) bool {
+	blacklistExist := func() bool {
+		kvPairs, _, err := c.api.KV().List("consul-alerts/config/checks/blacklist/", nil)
+		return len(kvPairs) != 0 && err == nil
+	}
+
 	node := check.Node
 	nodeCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/nodes/%s", node)
-	nodeBlacklisted := c.CheckKeyExists(nodeCheckKey)
+	nodeBlacklisted := func() bool { return c.CheckKeyExists(nodeCheckKey) }
 
 	service := "_"
-	serviceBlacklisted := false
+	serviceBlacklisted := func() bool { return false }
 	if check.ServiceID != "" {
 		service = check.ServiceID
 		serviceCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/services/%s", service)
-		serviceBlacklisted = c.CheckKeyExists(serviceCheckKey)
+		serviceBlacklisted = func() bool { return c.CheckKeyExists(serviceCheckKey) }
 	}
 
-	checkId := check.CheckID
-	checkCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/checks/%s", checkId)
-	checkBlacklisted := c.CheckKeyExists(checkCheckKey)
+	checkID := check.CheckID
+	checkCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/checks/%s", checkID)
+	checkBlacklisted := func() bool { return c.CheckKeyExists(checkCheckKey) }
 
-	singleKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/single/%s/%s/%s", node, service, checkId)
-	singleBlacklisted := c.CheckKeyExists(singleKey)
+	singleKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/single/%s/%s/%s", node, service, checkID)
+	singleBlacklisted := func() bool { return c.CheckKeyExists(singleKey) }
 
-	return nodeBlacklisted || serviceBlacklisted || checkBlacklisted || singleBlacklisted
+	return blacklistExist() && (nodeBlacklisted() || serviceBlacklisted() || checkBlacklisted() || singleBlacklisted())
 }
 
 func (c *ConsulAlertClient) CheckKeyExists(key string) bool {


### PR DESCRIPTION
Addresses one of scalability issues per https://github.com/AcalephStorage/consul-alerts/issues/57

By default, we do 4 GET requests against blacklist in the KV for each health check every 10s. If you have 1000 checks, it is 4000 requests even if you do not maintain any blacklists. This PR makes the function to return as soon as a match is found or immediately if there is no blacklist at all.