### PR TITLE
Fixes return string for NotifierName() method on AwsSnsNotifier struct

### DIFF
--- a/notifier/aws-sns-notifier.go
+++ b/notifier/aws-sns-notifier.go
@@ -16,7 +16,7 @@ type AwsSnsNotifier struct {
 
 // NotifierName provides name for notifier selection
 func (awssns *AwsSnsNotifier) NotifierName() string {
-	return "awsns"
+	return "awssns"
 }
 
 func (awssns *AwsSnsNotifier) Copy() Notifier {


### PR DESCRIPTION
NotifName returns 'awsns' string and should return 'awssns'