### PR TITLE
Add status-based notification profiles 

### DIFF
--- a/check-handler.go
+++ b/check-handler.go
@@ -108,7 +108,7 @@ func (c *CheckProcessor) handleChecks(checks []consul.Check) {
 func (c *CheckProcessor) notify(alerts []consul.Check) {
 	messages := make([]notifier.Message, len(alerts))
 	for i, alert := range alerts {
-		profileInfo := consulClient.GetProfileInfo(alert.Node, alert.ServiceID, alert.CheckID)
+		profileInfo := consulClient.GetProfileInfo(alert.Node, alert.ServiceID, alert.CheckID, alert.Status)
 		messages[i] = notifier.Message{
 			Node:         alert.Node,
 			ServiceId:    alert.ServiceID,

--- a/consul/client.go
+++ b/consul/client.go
@@ -746,7 +746,9 @@ func (c *ConsulAlertClient) IsBlacklisted(check *Check) bool {
 
 	node := check.Node
 	nodeCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/nodes/%s", node)
-	nodeBlacklisted := func() bool { return c.CheckKeyExists(nodeCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/nodes", node) }
+	nodeBlacklisted := func() bool {
+		return c.CheckKeyExists(nodeCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/nodes", node)
+	}
 
 	service := "_"
 	serviceBlacklisted := func() bool { return false }
@@ -754,13 +756,17 @@ func (c *ConsulAlertClient) IsBlacklisted(check *Check) bool {
 		service = check.ServiceID
 		serviceCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/services/%s", service)
 
-		serviceBlacklisted = func() bool { return c.CheckKeyExists(serviceCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/services", service) }
+		serviceBlacklisted = func() bool {
+			return c.CheckKeyExists(serviceCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/services", service)
+		}
 	}
 
 	checkID := check.CheckID
 	checkCheckKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/checks/%s", checkID)
 
-	checkBlacklisted := func() bool { return c.CheckKeyExists(checkCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/checks", checkID) }
+	checkBlacklisted := func() bool {
+		return c.CheckKeyExists(checkCheckKey) || c.CheckKeyMatchesRegexp("consul-alerts/config/checks/blacklist/checks", checkID)
+	}
 
 	singleKey := fmt.Sprintf("consul-alerts/config/checks/blacklist/single/%s/%s/%s", node, service, checkID)
 	singleBlacklisted := func() bool { return c.CheckKeyExists(singleKey) }

--- a/consul/client_test.go
+++ b/consul/client_test.go
@@ -78,7 +78,7 @@ func TestGetProfileForEntity(t *testing.T) {
 	client.api.KV().Put(&consulapi.KVPair{
 		Key:   "consul-alerts/config/notif-selection/services",
 		Value: data}, nil)
-	profile := client.getProfileForEntity("service", "_nomad-client")
+	profile := client.getProfileForEntity("services", "service", "_nomad-client")
 	if profile != "client-profile" {
 		t.Error("getProfileForEntity must have matched client-profile")
 	}
@@ -86,7 +86,7 @@ func TestGetProfileForEntity(t *testing.T) {
 	client.api.KV().Put(&consulapi.KVPair{
 		Key:   "consul-alerts/config/notif-selection/services/_nomad-server",
 		Value: []byte("server-profile")}, nil)
-	profile = client.getProfileForEntity("service", "_nomad-server")
+	profile = client.getProfileForEntity("services", "service", "_nomad-server")
 	if profile != "server-profile" {
 		t.Error("getProfileForEntity must have matched server-profile")
 	}
@@ -110,7 +110,7 @@ func TestGetProfileInfo(t *testing.T) {
 	client.api.KV().Put(&consulapi.KVPair{
 		Key:   "consul-alerts/config/notif-profiles/default",
 		Value: data}, nil)
-	checkProfileInfo := client.GetProfileInfo("node", "serviceID", "checkID")
+	checkProfileInfo := client.GetProfileInfo("node", "serviceID", "checkID", "status")
 	if !reflect.DeepEqual(checkProfileInfo, defaultProfileInfo) {
 		t.Error("Default profile info is loaded incorrectly")
 	}
@@ -153,7 +153,7 @@ func TestGetProfileInfo(t *testing.T) {
 		client.api.KV().Put(&consulapi.KVPair{
 			Key:   fmt.Sprintf("consul-alerts/config/notif-selection/%s", s.NotifSelection),
 			Value: []byte(s.NotifProfile)}, nil)
-		checkProfileInfo := client.GetProfileInfo("node", "serviceID", "checkID")
+		checkProfileInfo := client.GetProfileInfo("node", "serviceID", "checkID", "status")
 		if !reflect.DeepEqual(checkProfileInfo, profileInfo) {
 			t.Error("Profile info is loaded incorrectly")
 		}

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -92,7 +92,7 @@ type Consul interface {
 	CheckStatus(node, statusId, checkId string) (status, output string)
 	CheckKeyExists(key string) bool
 
-	GetProfileInfo(node, serviceID, checkID string) ProfileInfo
+	GetProfileInfo(node, serviceID, checkID, status string) ProfileInfo
 
 	GetReminders() []notifier.Message
 	SetReminder(m notifier.Message)


### PR DESCRIPTION
So that Warnings and Criticals can be treated separately.

I added it as the final check before the default fallback, so as not to affect existing installations.