### PR TITLE
Use better format for multi-line messages

### DIFF
--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -101,7 +101,7 @@ func (slack *SlackNotifier) notifyDetailed(messages Messages) bool {
 		detailedBody += fmt.Sprintf("\n*[%s:%s]* %s is *%s.*", message.Node, message.Service, message.Check, message.Status)
 		var msg = strings.TrimSpace(message.Output)
 		if len(msg) != 0 {
-			detailedBody += fmt.Sprintf("\n`%s`", msg)
+			detailedBody += fmt.Sprintf("\n```%s```", msg)
 		}
 	}
 


### PR DESCRIPTION
In Slack, single backticks are only applied to single line text and are treated as part of text when there is more than one line.   Triple backticks can be used to format one or more lines.