### PR TITLE
Add sns templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,10 +492,10 @@ prefix: `consul-alerts/config/notifiers/awssns/`
 | key          | description                                                  |
 |--------------|--------------------------------------------------------------|
 | enabled      | Enable the AWS SNS notifier.   [Default: false]              |
+| cluster-name | The name of the cluster.       [Default: "Consul Alerts"]    |
 | region       | AWS Region                     (mandatory)                   |
 | topic-arn    | Topic ARN to publish to.       (mandatory)                   |
-| template     | Path to custom email template. [Default: internal template]  |
-
+| template     | Path to custom template.       [Default: internal template]  |
 #### VictorOps
 
 To enable the VictorOps built-in notifier, set

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ prefix: `consul-alerts/config/notifiers/email/`
 | one-per-alert| Whether to send one email per alert [Default: false]                             |
 | one-per-node | Whether to send one email per node [Default: false] (overriden by one-per-alert) |
 
-The template can be any go html template. An `EmailData` instance will be passed to the template.
+The template can be any go html template. An `TemplateData` instance will be passed to the template.
 
 #### InfluxDB
 
@@ -489,11 +489,12 @@ needs to be configured.
 
 prefix: `consul-alerts/config/notifiers/awssns/`
 
-| key          | description                                         |
-|--------------|-----------------------------------------------------|
-| enabled      | Enable the AWS SNS notifier. [Default: false]       |
-| region       | AWS Region                           (mandatory)    |
-| topic-arn    | Topic ARN to publish to.             (mandatory)    |
+| key          | description                                                  |
+|--------------|--------------------------------------------------------------|
+| enabled      | Enable the AWS SNS notifier.   [Default: false]              |
+| region       | AWS Region                     (mandatory)                   |
+| topic-arn    | Topic ARN to publish to.       (mandatory)                   |
+| template     | Path to custom email template. [Default: internal template]  |
 
 #### VictorOps
 

--- a/consul/client.go
+++ b/consul/client.go
@@ -203,6 +203,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.ApiKey, val, ConfigTypeString)
 
 			// AwsSns notifier config
+			case "consul-alerts/config/notifiers/awssns/cluster-name":
+				valErr = loadCustomValue(&config.Notifiers.AwsSns.ClusterName, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/awssns/enabled":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/awssns/region":

--- a/consul/client.go
+++ b/consul/client.go
@@ -209,6 +209,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.Region, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/awssns/topic-arn":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.TopicArn, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/awssns/template":
+				valErr = loadCustomValue(&config.Notifiers.AwsSns.Template, val, ConfigTypeString)
 
 			// VictorOps notfier config
 			case "consul-alerts/config/notifiers/victorops/enabled":

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -154,7 +154,8 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 	}
 
 	awsSns := &notifier.AwsSnsNotifier{
-		Enabled: false,
+		Enabled:     false,
+		ClusterName: "Consul-Alerts",
 	}
 
 	victorOps := &notifier.VictorOpsNotifier{

--- a/notifier/aws-sns-notifier.go
+++ b/notifier/aws-sns-notifier.go
@@ -28,7 +28,7 @@ func (awssns *AwsSnsNotifier) Notify(messages Messages) bool {
 	subject := MakeSubject(messages)
 	body := MakeBody(messages)
 
-	return awssns.Send(subject, body)
+	return sendSNS(awssns, subject, body)
 }
 
 func MakeSubject(messages Messages) string {
@@ -44,7 +44,7 @@ func MakeBody(messages Messages) string {
 	return body
 }
 
-func (awssns *AwsSnsNotifier) Send(subject string, message string) bool {
+var sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool {
 	svc := sns.New(session.New(&aws.Config{
 		Region: aws.String(awssns.Region),
 	}))

--- a/notifier/aws-sns-notifier.go
+++ b/notifier/aws-sns-notifier.go
@@ -9,10 +9,11 @@ import (
 )
 
 type AwsSnsNotifier struct {
-	Enabled  bool
-	Template string `json:"template"`
-	Region   string `json:"region"`
-	TopicArn string `json:"topic-arn"`
+	ClusterName string `json:"cluster-name"`
+	Enabled     bool
+	Region      string `json:"region"`
+	TopicArn    string `json:"topic-arn"`
+	Template    string `json:"template"`
 }
 
 // NotifierName provides name for notifier selection
@@ -40,7 +41,7 @@ func (awssns *AwsSnsNotifier) makeSubject(messages Messages) string {
 func (awssns *AwsSnsNotifier) makeBody(messages Messages) string {
 	overallStatus, pass, warn, fail := messages.Summary()
 	t := TemplateData{
-		ClusterName:  "no-cluster-name",
+		ClusterName:  awssns.ClusterName,
 		SystemStatus: overallStatus,
 		FailCount:    fail,
 		WarnCount:    warn,

--- a/notifier/aws-sns-notifier.go
+++ b/notifier/aws-sns-notifier.go
@@ -10,6 +10,7 @@ import (
 
 type AwsSnsNotifier struct {
 	Enabled  bool
+	Template string `json:"template"`
 	Region   string `json:"region"`
 	TopicArn string `json:"topic-arn"`
 }
@@ -25,23 +26,35 @@ func (awssns *AwsSnsNotifier) Copy() Notifier {
 }
 
 func (awssns *AwsSnsNotifier) Notify(messages Messages) bool {
-	subject := MakeSubject(messages)
-	body := MakeBody(messages)
+	subject := awssns.makeSubject(messages)
+	body := awssns.makeBody(messages)
 
 	return sendSNS(awssns, subject, body)
 }
 
-func MakeSubject(messages Messages) string {
+func (awssns *AwsSnsNotifier) makeSubject(messages Messages) string {
 	overallStatus, pass, warn, fail := messages.Summary()
 	return fmt.Sprintf("%s--Fail: %d, Warn: %d, Pass: %d", overallStatus, fail, warn, pass)
 }
 
-func MakeBody(messages Messages) string {
-	body := ""
-	for _, message := range messages {
-		body += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
+func (awssns *AwsSnsNotifier) makeBody(messages Messages) string {
+	overallStatus, pass, warn, fail := messages.Summary()
+	t := TemplateData{
+		ClusterName:  "no-cluster-name",
+		SystemStatus: overallStatus,
+		FailCount:    fail,
+		WarnCount:    warn,
+		PassCount:    pass,
+		Nodes:        mapByNodes(messages),
 	}
-	return body
+
+	body, err := renderTemplate(t, awssns.Template, snsDefaultTemplate)
+	if err != nil {
+		log.Println("Template error, unable to send email notification: ", err)
+		return fmt.Sprintf("error rendering template %v", err)
+	} else {
+		return body
+	}
 }
 
 var sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool {
@@ -71,3 +84,6 @@ var sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool 
 
 	return true
 }
+
+var snsDefaultTemplate string = `
+{{ range $name, $checks := .Nodes }}{{ range $check := $checks }}{{ $name }}:{{$check.Service}}:{{$check.Check}} is {{$check.Status}}.{{ end }}{{ end }}`

--- a/notifier/aws-sns-notifier_test.go
+++ b/notifier/aws-sns-notifier_test.go
@@ -50,7 +50,7 @@ func TestNotifySNSWithCustomTemplate(t *testing.T) {
 	}()
 
 	expectedSubject := "CRITICAL--Fail: 1, Warn: 0, Pass: 0"
-	expectedMessage := "custom template: Failed: 1"
+	expectedMessage := "custom template: Failed: 1, cluster: some-cluster"
 
 	sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool {
 		if subject != expectedSubject {
@@ -62,17 +62,18 @@ func TestNotifySNSWithCustomTemplate(t *testing.T) {
 		return true
 	}
 
-	tmpfile, err := templateFile("custom template: Failed: {{ .FailCount }}")
+	tmpfile, err := templateFile("custom template: Failed: {{ .FailCount }}, cluster: {{ .ClusterName }}")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmpfile.Name())
 
 	notifier := AwsSnsNotifier{
-		Template: tmpfile.Name(),
-		Enabled:  true,
-		Region:   "some region",
-		TopicArn: "some-arn",
+		Template:    tmpfile.Name(),
+		Enabled:     true,
+		Region:      "some region",
+		TopicArn:    "some-arn",
+		ClusterName: "some-cluster",
 	}
 
 	messages := Messages{Message{

--- a/notifier/aws-sns-notifier_test.go
+++ b/notifier/aws-sns-notifier_test.go
@@ -1,8 +1,11 @@
 package notifier
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-func TestNotifySNS(t *testing.T) {
+func TestNotifySNSWithDefaultTemplate(t *testing.T) {
 	oldSendSNS := sendSNS
 
 	defer func() {
@@ -37,5 +40,48 @@ func TestNotifySNS(t *testing.T) {
 	if !notifier.Notify(messages) {
 		t.Error("Notify must return true")
 	}
+}
 
+func TestNotifySNSWithCustomTemplate(t *testing.T) {
+	oldSendSNS := sendSNS
+
+	defer func() {
+		sendSNS = oldSendSNS
+	}()
+
+	expectedSubject := "CRITICAL--Fail: 1, Warn: 0, Pass: 0"
+	expectedMessage := "custom template: Failed: 1"
+
+	sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool {
+		if subject != expectedSubject {
+			t.Errorf("expected subject to be %s, got %s", expectedSubject, subject)
+		}
+		if message != expectedMessage {
+			t.Errorf("expected message to be %s, got %s", expectedMessage, message)
+		}
+		return true
+	}
+
+	tmpfile, err := templateFile("custom template: Failed: {{ .FailCount }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	notifier := AwsSnsNotifier{
+		Template: tmpfile.Name(),
+		Enabled:  true,
+		Region:   "some region",
+		TopicArn: "some-arn",
+	}
+
+	messages := Messages{Message{
+		Node:    "some node",
+		Service: "some service",
+		Check:   "some check",
+		Status:  "critical",
+	}}
+	if !notifier.Notify(messages) {
+		t.Error("Notify must return true")
+	}
 }

--- a/notifier/aws-sns-notifier_test.go
+++ b/notifier/aws-sns-notifier_test.go
@@ -1,0 +1,41 @@
+package notifier
+
+import "testing"
+
+func TestNotifySNS(t *testing.T) {
+	oldSendSNS := sendSNS
+
+	defer func() {
+		sendSNS = oldSendSNS
+	}()
+
+	expectedSubject := "CRITICAL--Fail: 1, Warn: 0, Pass: 0"
+	expectedMessage := "\nsome node:some service:some check is critical."
+
+	sendSNS = func(awssns *AwsSnsNotifier, subject string, message string) bool {
+		if subject != expectedSubject {
+			t.Errorf("expected subject to be %s, got %s", expectedSubject, subject)
+		}
+		if message != expectedMessage {
+			t.Errorf("expected message to be %s, got %s", expectedMessage, message)
+		}
+		return true
+	}
+
+	notifier := AwsSnsNotifier{
+		Enabled:  true,
+		Region:   "some region",
+		TopicArn: "some-arn",
+	}
+
+	messages := Messages{Message{
+		Node:    "some node",
+		Service: "some service",
+		Check:   "some check",
+		Status:  "critical",
+	}}
+	if !notifier.Notify(messages) {
+		t.Error("Notify must return true")
+	}
+
+}

--- a/notifier/templating.go
+++ b/notifier/templating.go
@@ -1,0 +1,48 @@
+package notifier
+
+import (
+	"bytes"
+	"html/template"
+)
+
+type TemplateData struct {
+	ClusterName  string
+	SystemStatus string
+	FailCount    int
+	WarnCount    int
+	PassCount    int
+	Nodes        map[string]Messages
+}
+
+func (t TemplateData) IsCritical() bool {
+	return t.SystemStatus == SYSTEM_CRITICAL
+}
+
+func (t TemplateData) IsWarning() bool {
+	return t.SystemStatus == SYSTEM_UNSTABLE
+}
+
+func (t TemplateData) IsPassing() bool {
+	return t.SystemStatus == SYSTEM_HEALTHY
+}
+
+func renderTemplate(t TemplateData, templateFile string, defaultTemplate string) (string, error) {
+	var tmpl *template.Template
+	var err error
+	if templateFile == "" {
+		tmpl, err = template.New("base").Parse(defaultTemplate)
+	} else {
+		tmpl, err = template.ParseFiles(templateFile)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	var body bytes.Buffer
+	if err := tmpl.Execute(&body, t); err != nil {
+		return "", err
+	}
+
+	return body.String(), nil
+}

--- a/notifier/templating_test.go
+++ b/notifier/templating_test.go
@@ -1,0 +1,85 @@
+package notifier
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestRenderTemplateWithInvalidFile(t *testing.T) {
+	templateData := TemplateData{
+		ClusterName:  "some cluster",
+		SystemStatus: "some status",
+		FailCount:    1,
+		WarnCount:    2,
+		PassCount:    3,
+		Nodes:        make(map[string]Messages),
+	}
+
+	renderedTemplate, err := renderTemplate(templateData, "some-file-that-does-not-exist", "")
+
+	if err == nil {
+		t.Errorf("Expected error but rendered something: %s", renderedTemplate)
+	} else if err.Error() != "open some-file-that-does-not-exist: no such file or directory" {
+		t.Errorf("Expected error in opening file but got: %s", err.Error())
+	}
+}
+
+func TestRenderTemplate(t *testing.T) {
+	tmpfile, err := templateFile("{{ .SystemStatus }} - {{ .FailCount }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	templateData := TemplateData{
+		ClusterName:  "some cluster",
+		SystemStatus: "some status",
+		FailCount:    1,
+		WarnCount:    2,
+		PassCount:    3,
+		Nodes:        make(map[string]Messages),
+	}
+
+	renderedTemplate, err := renderTemplate(templateData, tmpfile.Name(), "")
+
+	if err != nil {
+		t.Errorf("Rendering failed: %v", err)
+	} else if renderedTemplate != "some status - 1" {
+		t.Errorf("Expected 'temporary file' but was '%v'", renderedTemplate)
+	}
+}
+
+func TestRenderDefaultTemplate(t *testing.T) {
+	templateData := TemplateData{
+		ClusterName:  "some cluster",
+		SystemStatus: "some status",
+		FailCount:    1,
+		WarnCount:    2,
+		PassCount:    3,
+		Nodes:        make(map[string]Messages),
+	}
+
+	renderedTemplate, err := renderTemplate(templateData, "", "{{ .SystemStatus }} - {{ .FailCount }}")
+
+	if err != nil {
+		t.Errorf("Rendering failed: %v", err)
+	} else if renderedTemplate != "some status - 1" {
+		t.Errorf("Expected 'temporary file' but was '%v'", renderedTemplate)
+	}
+}
+
+func templateFile(content string) (*os.File, error) {
+	tmpfile, err := ioutil.TempFile("", "consulAlertsTest")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		return nil, err
+	}
+	if err := tmpfile.Close(); err != nil {
+		return nil, err
+	}
+	return tmpfile, nil
+}


### PR DESCRIPTION
This PR introduces templating functionality for the body sent by the SNS notifier. 

It's designed to function like the templating mechanism of the E-Mail notifier and reuses a lot of its code. To conform to the same interface, this PR also adds the `clusterName` attribute to the SNS notifier. 

I wasn't sure how much you cared about compatibility so I stayed conservative here at the expense of consistency: By default, the notifier behaves as before, not including a clusterName. The clusterName can be used in custom templates though. This is different from other notifiers that set a default cluster-name and include it in default messages. Let me know if you prefer a different solution. 
