### PR TITLE
Enable cluster name override on slack integration

### DIFF
--- a/notifier/slack-notifier.go
+++ b/notifier/slack-notifier.go
@@ -14,7 +14,7 @@ import (
 )
 
 type SlackNotifier struct {
-	ClusterName string       `json:"-"`
+	ClusterName string       `json:"cluster_name"`
 	Url         string       `json:"-"`
 	Channel     string       `json:"channel"`
 	Username    string       `json:"username"`

--- a/notifier/slack_notifier_test.go
+++ b/notifier/slack_notifier_test.go
@@ -1,0 +1,45 @@
+package notifier
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestJsonUnmarshalling(t *testing.T) {
+	cluster_name := "my_cluster"
+	channel := "test_channel"
+	username := "test_username"
+	icon_url := "test_icon_url"
+	icon_emoji := "test_icon_emoji"
+	text := "test_text"
+
+	expectedNotifier := SlackNotifier{
+		ClusterName: cluster_name,
+		Channel:     channel,
+		Username:    username,
+		IconUrl:     icon_url,
+		IconEmoji:   icon_emoji,
+		Text:        text,
+	}
+	var unmarshalledNotifier SlackNotifier
+
+	data := []byte(fmt.Sprintf(`{
+    "cluster_name": "%s",
+    "channel": "%s",
+    "username": "%s",
+    "icon_url": "%s",
+    "icon_emoji": "%s",
+    "text": "%s"
+  }`, cluster_name, channel, username, icon_url, icon_emoji, text))
+
+	fmt.Printf("%s\n", data)
+	if err := json.Unmarshal(data, &unmarshalledNotifier); err != nil {
+		t.Error(err.Error())
+	}
+
+	if !reflect.DeepEqual(expectedNotifier, unmarshalledNotifier) {
+		t.Fatalf("Expected slackNotifier to be %s, got %s\n", expectedNotifier, unmarshalledNotifier)
+	}
+}


### PR DESCRIPTION
Problem: It's not possible to override the cluster name in Slack integration using `VarOverrides` object present in each `notif-profile`. The app will just ignore any `cluster_name` key present on `VarOverrides` on the selected profile and will use the default cluster name configured in the `notifier`.

This PR is intended to allow this kind of override as it will simplify the configuration in some use cases using only one slack `notifier` and override the cluster name in the corresponding `notif-profiles` 