### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ service "" {
 event "" {
   policy = "read"
 }
+
+session "" {
+  policy = "write"
+}
 ```
 
 ### Health Checks


### PR DESCRIPTION
When Consul is setting up by ACL, Consul-alert only works when granted with session ACL.
Tested version:
Consul 0.9.2 default ACL set to deny
Consul-alert  0.3.2
