### PR TITLE
WIP: Updated Mattermost notifer to support Incoming WebHooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,17 +438,24 @@ Mattermost integration is also supported. To enable, set
 `consul-alerts/config/notifiers/mattermost/enabled` to `true`. Mattermost details needs to
 be configured.
 
+Mattermost notifier comes in two modes:
+* Authorized POST (default)
+* Incoming WebHooks POST
+
+If you want to use the [Incoming WebHooks](https://docs.mattermost.com/developer/webhooks-incoming.html), you must enabled `consul-alerts/config/notifiers/mattermost/webhooked` to `true`, and specify the Mattermost URL generated for your applicationin `url`.
+
 prefix: `consul-alerts/config/notifiers/mattermost/`
 
-| key          | description                                         |
-|--------------|-----------------------------------------------------|
-| enabled      | Enable the Mattermost notifier. [Default: false]    |
-| cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
-| url          | The mattermost url (mandatory)                      |
-| username     | The mattermost username (mandatory)                 |
-| password     | The mattermost password (mandatory)                 |
-| team         | The mattermost team (mandatory)                     |
-| channel      | The channel to post the notification (mandatory)    |
+| key          | description                                                    |
+|--------------|----------------------------------------------------------------|
+| enabled      | Enable the Mattermost notifier. [Default: false]               |
+| cluster-name | The name of the cluster. [Default: "Consul Alerts"]            |
+| url          | The mattermost url (mandatory)                                 |
+| username     | The mattermost username (mandatory)                            |
+| password     | The mattermost password (mandatory)                            |
+| team         | The mattermost team (mandatory)                                |
+| channel      | The channel to post the notification (mandatory)               |
+| webhooked    | Enable the Incomming WebHooks for Mattermost. [Default: false] |
 
 #### PagerDuty
 


### PR DESCRIPTION
- Purpose: add a second way to notify with Mattermost, using Incoming WebHooks.
- Made changes based on Slack notifier.
- TODO: - testing.

@Gerrrr please let me know if the idea makes sense or if you have any suggestions :)