### PR TITLE
Alerta notifier implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,22 @@ prefix: `consul-alerts/config/notifiers/victorops/`
 | enabled      | Enable the VictorOps notifier. [Default: false]     |
 | api-key      | API Key                              (mandatory)    |
 | routing-key  | Routing Key                          (mandatory)    |
+#### Alerta
+
+To enable the Alerta built-in notifier, set
+`consul-alerts/config/notifiers/alerta/enabled` to `true`. Alerta details
+needs to be configured.
+
+prefix: `consul-alerts/config/notifiers/alerta/`
+
+| key          | description                                                                                                                                                   |
+|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| enabled      | Enable the Alerta notifier. [Default: false]                                                                                                                  |
+| token        | API Token                            (mandatory)                                                                                                              |
+| url          | Alerta API url                       (mandatory)                                                                                                              |
+| cluster-name | The name of the cluster.                                                                                                                                      |
+| domain       | You domain. Available to use in link template                                                                                                                 |
+| link         | Templateable link. Example: https://hashiui.{{ .Notifier.ClusterName }}.{{ .Notifier.Domain }}/consul/{{ .Notifier.ClusterName }}/services/{{ .Msg.Service }} |
 
 
 Health Check via API

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -249,6 +249,7 @@ func builtinNotifiers() map[string]notifier.Notifier {
 	opsgenieNotifier := consulClient.OpsGenieNotifier()
 	awssnsNotifier := consulClient.AwsSnsNotifier()
 	victoropsNotifier := consulClient.VictorOpsNotifier()
+	alertaNotifier := consulClient.AlertaNotifier()
 
 	notifiers := map[string]notifier.Notifier{}
 	if emailNotifier.Enabled {
@@ -284,6 +285,10 @@ func builtinNotifiers() map[string]notifier.Notifier {
 
 	if victoropsNotifier.Enabled {
 		notifiers[victoropsNotifier.NotifierName()] = victoropsNotifier
+	}
+
+	if alertaNotifier.Enabled {
+		notifiers[alertaNotifier.NotifierName()] = alertaNotifier
 	}
 
 	return notifiers

--- a/consul/client.go
+++ b/consul/client.go
@@ -21,6 +21,7 @@ const (
 	ConfigTypeString
 	ConfigTypeInt
 	ConfigTypeStrArray
+	// ConfigTypeMapStrInterface
 )
 
 type configType int
@@ -235,12 +236,33 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.VictorOps.APIKey, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/victorops/routing-key":
 				valErr = loadCustomValue(&config.Notifiers.VictorOps.RoutingKey, val, ConfigTypeString)
+
+			// Alerta notifier config
+			case "consul-alerts/config/notifiers/alerta/enabled":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Enabled, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/alerta/url":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Url, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/cluster-name":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.ClusterName, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/token":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Token, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/domain":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Domain, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/type":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Type, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/origin":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Origin, val, ConfigTypeString)
+
+			// AlertaAttributes
+			case "consul-alerts/config/notifiers/alerta/attributes/link":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Attributes.Link, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/alerta/attributes/ack":
+				valErr = loadCustomValue(&config.Notifiers.Alerta.Attributes.Ack, val, ConfigTypeString)
 			}
 
 			if valErr != nil {
 				log.Printf(`unable to load custom value for "%s". Using default instead. Error: %s`, key, valErr.Error())
 			}
-
 		}
 	} else {
 		log.Println("Unable to load custom config, using default instead:", err)
@@ -528,6 +550,10 @@ func (c *ConsulAlertClient) AwsSnsNotifier() *notifier.AwsSnsNotifier {
 
 func (c *ConsulAlertClient) VictorOpsNotifier() *notifier.VictorOpsNotifier {
 	return c.config.Notifiers.VictorOps
+}
+
+func (c *ConsulAlertClient) AlertaNotifier() *notifier.AlertaNotifier {
+	return c.config.Notifiers.Alerta
 }
 
 func (c *ConsulAlertClient) registerHealthCheck(key string, health *Check) {

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -80,6 +80,7 @@ type Consul interface {
 	OpsGenieNotifier() *notifier.OpsGenieNotifier
 	AwsSnsNotifier() *notifier.AwsSnsNotifier
 	VictorOpsNotifier() *notifier.VictorOpsNotifier
+	AlertaNotifier() *notifier.AlertaNotifier
 
 	CheckChangeThreshold() int
 	UpdateCheckData()
@@ -168,6 +169,10 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		Enabled: false,
 	}
 
+	alerta := &notifier.AlertaNotifier{
+		Enabled: false,
+	}
+
 	notifiers := &notifier.Notifiers{
 		Email:             email,
 		Log:               log,
@@ -180,6 +185,7 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		OpsGenie:          opsgenie,
 		AwsSns:            awsSns,
 		VictorOps:         victorOps,
+		Alerta:            alerta,
 		Custom:            []string{},
 	}
 

--- a/notifier/alerta-notifier.go
+++ b/notifier/alerta-notifier.go
@@ -1,0 +1,158 @@
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"text/template"
+
+	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+type AlertaNotifier struct {
+	ClusterName string           `json:"-"`
+	Domain      string           `json:"-"`
+	Url         string           `json:"-"`
+	Token       string           `json:"-"`
+	Text        string           `json:"text,omitempty"`
+	Environment string           `json:"environment"`
+	Resource    string           `json:"resource"`
+	Event       string           `json:"event"`
+	Enabled     bool             `json:"-"`
+	Type        string           `json:"type"`
+	Origin      string           `json:"origin"`
+	Status      string           `json:"status"`
+	Service     []string         `json:"service"`
+	Attributes  AlertaAttributes `json:"attributes"`
+	Severity    string           `json:"severity"`
+}
+
+type AlertaAttributes struct {
+	Link string `json:"link"`
+	Ack  string `json:"ack"`
+}
+
+type TmplMsg struct {
+	Notifier *AlertaNotifier
+	Msg      Message
+}
+
+// populateDefaults set default values
+func (n *AlertaNotifier) populate(message Messages) {
+	if n.Type == "" {
+		n.Type = "consul-alerts"
+	}
+
+	if n.Origin == "" {
+		n.Origin = strings.Join([]string{n.ClusterName, n.Domain}, ".")
+	}
+
+	if n.Environment == "" {
+		n.Environment = "Production"
+	}
+
+	msg := message[0]
+	n.Resource = msg.Node
+	n.Event = msg.Check
+	n.Service = append(n.Service, msg.Service)
+
+	if n.Attributes.Link != "" {
+		t := TmplMsg{
+			Notifier: n,
+			Msg:      msg,
+		}
+		tmpl, err := template.New("link").Parse(n.Attributes.Link)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		var link bytes.Buffer
+		err = tmpl.Execute(&link, t)
+		if err != nil {
+			return
+		}
+		n.Attributes.Link = link.String()
+	}
+
+	if msg.IsCritical() {
+		n.Severity = "major"
+		n.Status = "open"
+	}
+	if msg.IsWarning() {
+		n.Severity = "warning"
+		n.Status = "open"
+	}
+	if msg.IsPassing() {
+		n.Severity = "ok"
+		n.Status = "closed"
+	}
+}
+
+// NotifierName provides name for notifier selection
+func (n *AlertaNotifier) NotifierName() string {
+	return "alerta"
+}
+
+func (n *AlertaNotifier) Copy() Notifier {
+	notifier := *n
+	return &notifier
+}
+
+//Notify sends messages to the endpoint notifier
+func (n *AlertaNotifier) Notify(messages Messages) bool {
+	return n.notifySimple(messages)
+}
+
+func (n *AlertaNotifier) notifySimple(messages Messages) bool {
+	overallStatus, pass, warn, fail := messages.Summary()
+	text := fmt.Sprintf(header, n.ClusterName, overallStatus, fail, warn, pass)
+	for _, message := range messages {
+		text += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
+		text += fmt.Sprintf("\n%s", message.Output)
+	}
+	n.Text = text
+	n.populate(messages)
+
+	return n.postToAlerta()
+}
+
+func (n *AlertaNotifier) postToAlerta() bool {
+	jsonData, err := json.Marshal(n)
+	if err != nil {
+		log.Println("Unable to marshal Alerta payload:", err)
+		return false
+	}
+
+	log.Debugf("struct = %+v, payload = %s", n, string(jsonData))
+
+	client := http.Client{}
+	b := bytes.NewBufferString(string(jsonData))
+	req, err := http.NewRequest("POST", n.Url, b)
+	if err != nil {
+		log.Println("Unable to send data to Alerta: ", err.Error())
+		return false
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", n.Token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		log.Println("Unable to send data to Alerta:", err)
+		return false
+	}
+	defer res.Body.Close()
+
+	statusCode := res.StatusCode
+	if statusCode > 202 {
+		body, _ := ioutil.ReadAll(res.Body)
+		log.Println("Unable to notify Alerta: ", string(body))
+		return false
+	}
+	log.Println("Alerta notification sent.")
+	return true
+}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -52,6 +52,7 @@ type Notifiers struct {
 	OpsGenie          *OpsGenieNotifier          `json:"opsgenie"`
 	AwsSns            *AwsSnsNotifier            `json:"awssns"`
 	VictorOps         *VictorOpsNotifier         `json:"victorops"`
+	Alerta            *AlertaNotifier            `json:"alerta"`
 	Custom            []string                   `json:"custom"`
 }
 
@@ -79,6 +80,8 @@ func (n Notifiers) GetNotifier(name string) (Notifier, bool) {
 		return n.AwsSns, true
 	case n.VictorOps != nil && n.VictorOps.NotifierName() == name:
 		return n.VictorOps, true
+	case n.Alerta != nil && n.Alerta.NotifierName() == name:
+		return n.Alerta, true
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
See http://alerta.io for more information about it.

"consul-alerts/config/notifiers/alerta/" prefix added

Config options:

* enabled      bool   Enable/Disable notifier
* url          string Url to Alerta API
* token        string API token with write access
* cluster-name string The name of the cluster
* domain       string You domain. Usable for link templating
* link         string Templateable link to smth. Example: https://hashiui.{{ .Notifier.ClusterName
  }}.{{ .Notifier.Domain }}/consul/{{ .Notifier.ClusterName }}/services/{{ .Msg.Service }}
* origin       string
* type         string Default: consul-alerts