### PR TITLE
Implement retry configs for pagerduty notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,12 +473,14 @@ To enable PagerDuty built-in notifier, set `consul-alerts/config/notifiers/pager
 
 prefix: `consul-alerts/config/notifiers/pagerduty/`
 
-| key         | description                                     |
-|-------------|-------------------------------------------------|
-| enabled     | Enable the PagerDuty notifier. [Default: false] |
-| service-key | Service key to access PagerDuty                 |
-| client-name | The monitoring client name                      |
-| client-url  | The monitoring client url                       |
+| key                 | description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| enabled             | Enable the PagerDuty notifier. [Default: false]                      |
+| service-key         | Service key to access PagerDuty                                      |
+| client-name         | The monitoring client name                                           |
+| client-url          | The monitoring client url                                            |
+| max-retry           | The upper limit of retries on failure. [Default: `0` for no retries] |
+| retry-base-interval | The base delay in seconds before a retry. [Default: `30` seconds ]   |
 
 #### HipChat
 

--- a/consul/client.go
+++ b/consul/client.go
@@ -193,6 +193,10 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.PagerDuty.ClientName, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/pagerduty/client-url":
 				valErr = loadCustomValue(&config.Notifiers.PagerDuty.ClientUrl, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/pagerduty/max-retry":
+				valErr = loadCustomValue(&config.Notifiers.PagerDuty.MaxRetry, val, ConfigTypeInt)
+			case "consul-alerts/config/notifiers/pagerduty/retry-base-interval":
+				valErr = loadCustomValue(&config.Notifiers.PagerDuty.RetryBaseInterval, val, ConfigTypeInt)
 
 			// hipchat notfier config
 			case "consul-alerts/config/notifiers/hipchat/enabled":

--- a/notifier/pagerduty-notifier.go
+++ b/notifier/pagerduty-notifier.go
@@ -1,16 +1,19 @@
 package notifier
 
 import (
-	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/darkcrux/gopherduty"
-
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/darkcrux/gopherduty"
 )
 
+const defaultRetryBaseInterval = 30
+
 type PagerDutyNotifier struct {
-	Enabled    bool
-	ServiceKey string `json:"service-key"`
-	ClientName string `json:"client-name"`
-	ClientUrl  string `json:"client-url"`
+	Enabled           bool
+	ServiceKey        string `json:"service-key"`
+	ClientName        string `json:"client-name"`
+	ClientUrl         string `json:"client-url"`
+	MaxRetry          int    `json:"max-retry"`
+	RetryBaseInterval int    `json:"retry-base-interval"'`
 }
 
 // NotifierName provides name for notifier selection
@@ -27,6 +30,16 @@ func (pd *PagerDutyNotifier) Copy() Notifier {
 func (pd *PagerDutyNotifier) Notify(messages Messages) bool {
 
 	client := gopherduty.NewClient(pd.ServiceKey)
+
+	if pd.MaxRetry != 0 {
+		client.MaxRetry = pd.MaxRetry
+
+		if pd.RetryBaseInterval != 0 {
+			client.RetryBaseInterval = pd.RetryBaseInterval
+		} else {
+			client.RetryBaseInterval = defaultRetryBaseInterval
+		}
+	}
 
 	result := true
 

--- a/notifier/pagerduty_notifier_test.go
+++ b/notifier/pagerduty_notifier_test.go
@@ -1,0 +1,56 @@
+package notifier
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPagerDuty_StandardConfig(t *testing.T) {
+	emptyMessages := Messages{}
+
+	pd := PagerDutyNotifier{
+		ClientName: "pagerduty",
+		ClientUrl:  "example.com",
+		Enabled:    true,
+		ServiceKey: "longdummykey",
+	}
+
+	success := pd.Notify(emptyMessages)
+
+	if !success {
+		t.Fatalf("Expected Notify success with regular config and zero messages")
+	}
+}
+
+func TestPagerDuty_WithOptionalConfigs(t *testing.T) {
+	emptyMessages := Messages{}
+
+	suite := []struct {
+		name              string
+		maxRetry          int
+		retryBaseInterval int
+	}{
+		{"with MaxRetry", 5, 0},
+		{"with RetryBaseInterval", 0, 30},
+		{"with both MaxRetry RetryBaseInterval", 5, 30},
+	}
+
+	for _, tc := range suite {
+		t.Run(tc.name, func(t *testing.T) {
+			pd := PagerDutyNotifier{
+				ClientName: "pagerduty",
+				ClientUrl:  "example.com",
+				Enabled:    true,
+				ServiceKey: "longdummykey",
+			}
+			pd.MaxRetry = tc.maxRetry
+			pd.RetryBaseInterval = tc.retryBaseInterval
+			fmt.Printf("pd: %+v\n", pd)
+			success := pd.Notify(emptyMessages)
+
+			if !success {
+				t.Fatalf("Expected Notify success for config '%s' and zero messages", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* add MaxRetries and RetryBaseInterval to pagerduty notifier
* read those values from Consul on start
* set values on client if configured
* add tests of client with / without MaxRetries, RetryBaseInterval
* README: add new items in PagerDuty section