### PR TITLE
Added token in argument of consul watch command

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -170,10 +170,10 @@ func daemonMode(arguments map[string]interface{}) {
 	log.Println("Started Consul-Alerts API")
 
 	if watchChecks {
-		go runWatcher(consulAddr, consulDc, addr, loglevelString, "checks")
+		go runWatcher(consulAddr, consulDc, addr, loglevelString, consulAclToken, "checks")
 	}
 	if watchEvents {
-		go runWatcher(consulAddr, consulDc, addr, loglevelString, "event")
+		go runWatcher(consulAddr, consulDc, addr, loglevelString, consulAclToken, "event")
 	}
 
 	ch := make(chan os.Signal)

--- a/watchers.go
+++ b/watchers.go
@@ -12,12 +12,13 @@ import (
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
-func runWatcher(consulAddr, datacenter, alertAddr, logLevel, watchType string) {
+func runWatcher(consulAddr, datacenter, alertAddr, logLevel, consulAclToken, watchType string) {
 	consulAlert := os.Args[0]
 	cmd := exec.Command(
 		"consul", "watch",
 		"-http-addr", consulAddr,
 		"-datacenter", datacenter,
+		"-token", consulAclToken,
 		"-type", watchType,
 		consulAlert, "watch", watchType, "--alert-addr", alertAddr, "--log-level", logLevel)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
To make watchers support Consul ACL, I added token in argument of consul watch command.  

Of course I know that consul-alerts supports ACLs, but since consul-alerts do not pass token as an argument to the consul watch command, we can only use the default ACL token.  
Therefore, I think that it is better to change to explicitly pass token to consul watch command.  

ref. https://www.consul.io/docs/agent/watches.html#token