### PR TITLE
publish/distribute consul-alerts as a compressed .tgz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-all: test
 package: build-all
 	@echo "--> Packaging application"
 	@for arch in ${BUILD_ARCHS}; do \
-		tar cf build/tar/${APP_NAME}-${VERSION}-$${arch}.tar -C build/bin/$${arch}/${VERSION} ${APP_NAME} ; \
+		tar czf build/tar/${APP_NAME}-${VERSION}-$${arch}.tgz -C build/bin/$${arch}/${VERSION} ${APP_NAME} ; \
 	done
 
 release: package
@@ -51,7 +51,7 @@ ifeq ($(VERSION) , latest)
 endif
 	@echo "--> Releasing version: ${VERSION}"
 	@for arch in ${BUILD_ARCHS}; do \
-		curl -s -T "build/tar/${APP_NAME}-${VERSION}-$${arch}.tar" -u "${ACCESS_KEY}" "https://api.bintray.com/content/darkcrux/generic/${APP_NAME}/${VERSION}/${APP_NAME}-${VERSION}-$${arch}.tar"; \
+		curl -s -T "build/tar/${APP_NAME}-${VERSION}-$${arch}.tgz" -u "${ACCESS_KEY}" "https://api.bintray.com/content/darkcrux/generic/${APP_NAME}/${VERSION}/${APP_NAME}-${VERSION}-$${arch}.tgz"; \
 		echo "... $${arch}"; \
 	done
 	@echo "--> Publishing version ${VERSION}"


### PR DESCRIPTION
ATM nomad is unable to unarchive the `.tar` distribution. See https://github.com/hashicorp/go-getter/issues/19 and https://github.com/hashicorp/nomad/issues/2443 for history on the topic. This update allows nomad to use go-getter to download and run consul-alerts. While I would prefer nomad be updated to support `.tar`, it's been years, and we haven't seen that happen.