### PR TITLE
add support for MessageType config for VictorOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,11 +567,12 @@ needs to be configured.
 
 prefix: `consul-alerts/config/notifiers/victorops/`
 
-| key          | description                                         |
-|--------------|-----------------------------------------------------|
-| enabled      | Enable the VictorOps notifier. [Default: false]     |
-| api-key      | API Key                              (mandatory)    |
-| routing-key  | Routing Key                          (mandatory)    |
+| key          | description                                             |
+|--------------|---------------------------------------------------------|
+| enabled      | Enable the VictorOps notifier. [Default: false]         |
+| api-key      | API Key                                  (mandatory)    |
+| routing-key  | Routing Key                              (mandatory)    |
+| message-type | Message type like CRITIAL or WARNING.    (optional)     |
 
 #### HTTP Endpoint
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659389018,
+        "narHash": "sha256-x1yBwEIPJcJJrz9kOdeHqIEk9f7eYVrxmPV8417Tf6o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fb01fab4f38dbcf6e5e55a786aef0d77fe28865",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fb01fab4f38dbcf6e5e55a786aef0d77fe28865",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Nix flake for consul-alerts.";
+
+  # Locked to provide Go 1.17.13.
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/8fb01fab4f38dbcf6e5e55a786aef0d77fe28865;
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux" "i686-linux" "aarch64-linux"
+        "x86_64-darwin" "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      pkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in rec {
+      devShells = forAllSystems (system: let
+        pkgs = pkgsFor.${system};
+      in {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [ go_1_17 ];
+        };
+      });
+  };
+}

--- a/notifier/victorops-notifier.go
+++ b/notifier/victorops-notifier.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -134,8 +135,18 @@ func (vo *VictorOpsNotifier) Notify(messages Messages) bool {
 			log.Error(fmt.Sprintf("Expected VictorOps endpoint to return 200, but it returned %d", response.StatusCode))
 			continue
 		}
+
+		bodyBytes, readError := io.ReadAll(response.Body)
+		if readError != nil {
+			log.Error(fmt.Sprintf("Failed to read VictorOps APi response: %s", readError))
+			continue
+		}
+		responseBody := string(bodyBytes)
+
+		log.Printf("VictorOps event sent: entityID:%s, type:%s", entityID, messageType)
+		log.Debugf("VictorOps response(%d): %s", response.StatusCode, responseBody)
 	}
 
-	log.Println("VictorOps notification sent.")
+	log.Println("VictorOps notifications sent.")
 	return ok
 }

--- a/notifier/victorops-notifier.go
+++ b/notifier/victorops-notifier.go
@@ -12,9 +12,10 @@ import (
 
 // VictorOpsNotifier provides configuration options for the VictorOps notifier
 type VictorOpsNotifier struct {
-	Enabled    bool
-	APIKey     string `json:"api-key"`
-	RoutingKey string `json:"routing-key"`
+	Enabled     bool
+	APIKey      string `json:"api-key"`
+	RoutingKey  string `json:"routing-key"`
+	MessageType string `json:"message-type"`
 }
 
 // VictorOpsEvent represents the options we'll pass to the VictorOps API
@@ -74,16 +75,20 @@ func (vo *VictorOpsNotifier) Notify(messages Messages) bool {
 
 		var messageType string
 
-		switch {
-		case message.IsCritical():
-			messageType = "CRITICAL"
-		case message.IsWarning():
-			messageType = "WARNING"
-		case message.IsPassing():
-			messageType = "RECOVERY"
-		default:
-			log.Warn(fmt.Sprintf("Message with status %s was neither critical, warning, nor passing, reporting to VictorOps as INFO", message.Status))
-			messageType = "INFO"
+		if vo.MessageType != "" {
+			messageType = vo.MessageType
+		} else {
+			switch {
+			case message.IsCritical():
+				messageType = "CRITICAL"
+			case message.IsWarning():
+				messageType = "WARNING"
+			case message.IsPassing():
+				messageType = "RECOVERY"
+			default:
+				log.Warn(fmt.Sprintf("Message with status %s was neither critical, warning, nor passing, reporting to VictorOps as INFO", message.Status))
+				messageType = "INFO"
+			}
 		}
 
 		// VictorOps automatically displays the entity display name in notifications and page SMSs / emails,


### PR DESCRIPTION
Necessary to separate alerts severity based on fleet or hostnames.